### PR TITLE
Parse HTML character entities in output message.

### DIFF
--- a/lib/linter-phpcs.coffee
+++ b/lib/linter-phpcs.coffee
@@ -36,7 +36,7 @@ class LinterPhpcs extends Linter
     super
     @disposables.dispose()
 
-   updateCommand: ->
+  updateCommand: ->
     standard = atom.config.get 'linter-phpcs.standard'
     ignore = atom.config.get 'linter-phpcs.ignore'
     warning = atom.config.get 'linter-phpcs.enableWarning'
@@ -55,5 +55,21 @@ class LinterPhpcs extends Linter
 
       if ignore
         @cmd += " --ignore=#{ignore}"
+
+  # Parse HTML character entities in output.
+  formatMessage: (match) ->
+    map = {
+      quot: '"'
+      amp: '&'
+      lt: '<'
+      gt: '>'
+    }
+    message = match.message
+
+    for key,value of map
+      regex = new RegExp '&' + key + ';', 'g'
+      message = message.replace(regex, value)
+
+    return message
 
 module.exports = LinterPhpcs


### PR DESCRIPTION
Lint messages will sometimes have `&quot;` instead of `"` or similar—this should fix that, at least for common/likely characters (`&`, `"`, `<`, and `>`).