### PR TITLE
Custom name path for xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You can configure linter-phpcs by editing ~/.atom/config.cson (choose Open Your 
 ```
 'linter-phpcs':
   'phpcsExecutablePath': null #phpcs path. run 'which phpcs' to find the path
+  'phpcsConfigXMLPath': null #phpcs XML path. directory to look for XML standards file, cwd by default
+  'phpcsConfigXMLFile': 'phpcs.xml' #phpcs XML name. name of the file to search for
   'standard': 'PSR2' #phpcs standard
   'ignore': '*.blade.php,*.twig.php' #phpcs ignore files
   'enableWarning': 1 #phpcs warning-severity 1 = true | 0 = false

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,6 +3,12 @@ module.exports =
     phpcsExecutablePath:
       type: 'string'
       default: ''
+    phpcsConfigXMLPath:
+      type: 'string'
+      default: ''
+    phpcsConfigXMLFile:
+      type: 'string'
+      default: 'phpcs.xml'
     standard:
       type: 'string'
       default: 'PSR2'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,10 +3,10 @@ module.exports =
     phpcsExecutablePath:
       type: 'string'
       default: ''
-    phpcsConfigXMLPath:
+    phpcsConfigXmlPath:
       type: 'string'
       default: ''
-    phpcsConfigXMLFile:
+    phpcsConfigXmlFile:
       type: 'string'
       default: 'phpcs.xml'
     standard:

--- a/lib/linter-phpcs.coffee
+++ b/lib/linter-phpcs.coffee
@@ -23,6 +23,12 @@ class LinterPhpcs extends Linter
     @disposables.add atom.config.observe 'linter-phpcs.phpcsExecutablePath', =>
       @executablePath = atom.config.get 'linter-phpcs.phpcsExecutablePath'
 
+    @disposables.add atom.config.observe 'linter-phpcs.phpcsConfigXMLPath', =>
+      @updateCommand()
+
+    @disposables.add atom.config.observe 'linter-phpcs.phpcsConfigXMLFile', =>
+      @updateCommand()
+
     @disposables.add atom.config.observe 'linter-phpcs.standard', =>
       @updateCommand()
 
@@ -36,18 +42,24 @@ class LinterPhpcs extends Linter
     super
     @disposables.dispose()
 
-   updateCommand: ->
+  updateCommand: ->
     standard = atom.config.get 'linter-phpcs.standard'
     ignore = atom.config.get 'linter-phpcs.ignore'
     warning = atom.config.get 'linter-phpcs.enableWarning'
+    configXMLPath = atom.config.get 'linter-phpcs.phpcsConfigXMLPath'
+    configXMLFile = atom.config.get 'linter-phpcs.phpcsConfigXMLFile'
 
     @cmd = "phpcs --report=checkstyle --warning-severity=#{warning}"
 
     # Check for per-project settings and fall back to editor settings
     # if none are found.
-    config = findFile @cwd, ['phpcs.xml']
-    if config
-      @cmd += " --standard=#{config}"
+    cwdXML = findFile @cwd, [configXMLFile]
+    configXML = findFile configXMLPath, [configXMLFile]
+    if cwdXML
+      @cmd += " --standard=#{cwdXML}"
+
+    else if configXML
+      @cmd += " --standard=#{configXML}"
 
     else
       if standard

--- a/lib/linter-phpcs.coffee
+++ b/lib/linter-phpcs.coffee
@@ -23,10 +23,10 @@ class LinterPhpcs extends Linter
     @disposables.add atom.config.observe 'linter-phpcs.phpcsExecutablePath', =>
       @executablePath = atom.config.get 'linter-phpcs.phpcsExecutablePath'
 
-    @disposables.add atom.config.observe 'linter-phpcs.phpcsConfigXMLPath', =>
+    @disposables.add atom.config.observe 'linter-phpcs.phpcsConfigXmlPath', =>
       @updateCommand()
 
-    @disposables.add atom.config.observe 'linter-phpcs.phpcsConfigXMLFile', =>
+    @disposables.add atom.config.observe 'linter-phpcs.phpcsConfigXmlFile', =>
       @updateCommand()
 
     @disposables.add atom.config.observe 'linter-phpcs.standard', =>
@@ -46,8 +46,8 @@ class LinterPhpcs extends Linter
     standard = atom.config.get 'linter-phpcs.standard'
     ignore = atom.config.get 'linter-phpcs.ignore'
     warning = atom.config.get 'linter-phpcs.enableWarning'
-    configXMLPath = atom.config.get 'linter-phpcs.phpcsConfigXMLPath'
-    configXMLFile = atom.config.get 'linter-phpcs.phpcsConfigXMLFile'
+    configXMLPath = atom.config.get 'linter-phpcs.phpcsConfigXmlPath'
+    configXMLFile = atom.config.get 'linter-phpcs.phpcsConfigXmlFile'
 
     @cmd = "phpcs --report=checkstyle --warning-severity=#{warning}"
 


### PR DESCRIPTION
Sort of for #26 I have a custom phpcs XML that I keep static for multiple projects.

Linter is ok (except for line 14 ;-) )
```
$ coffeelint .
  ✓ ./lib/init.coffee
  ✗ ./lib/linter-phpcs.coffee
     ✗ #14: Line exceeds maximum allowed length. Length is 140, max is 80.

✗ Lint! » 1 error and 0 warnings in 2 files
```