### PR TITLE
add support for phpcs.ruleset.xml files

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -64,8 +64,7 @@ module.exports =
         parameters = @parameters.filter (item) -> item
         standard = @standard
         command = @command
-        if standard is 'PSR2' # default value
-          standard = helpers.findFile(path.dirname(filePath), 'phpcs.xml') or standard
+        standard = helpers.findFile(path.dirname(filePath), 'phpcs.xml') or helpers.findFile(path.dirname(filePath), 'phpcs.ruleset.xml') or standard
         if standard then parameters.push("--standard=#{standard}")
         parameters.push('--report=json')
         parameters.push(filePath)


### PR DESCRIPTION
The WordPress community often use phpcs.ruleset.xml files instead of phpcs.xml files