### PR TITLE
Add linter name

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -57,6 +57,7 @@ module.exports =
     path = require 'path'
     helpers = require('atom-linter')
     provider =
+      name: 'PHPCS'
       grammarScopes: ['source.php']
       scope: 'file'
       lintOnFly: true


### PR DESCRIPTION
Specifies the linter name, allowing the `linter` package to display it if the user chooses to.