### PR TITLE
fixes #73

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -95,7 +95,7 @@ module.exports =
         standard = @standard
         command = @command
         confFile = helpers.findFile(path.dirname(filePath), ['phpcs.xml', 'phpcs.ruleset.xml'])
-        standard = if @autoConfigSearch then confFile else standard
+        standard = if @autoConfigSearch and confFile then confFile else standard
         return [] if @disableWhenNoConfigFile and not confFile
         if standard then parameters.push("--standard=#{standard}")
         parameters.push('--report=json')


### PR DESCRIPTION
Actually @AustP is right. If `autoConfigSearch` is enabled it always
loads the `confFile` if there is one or not. This commit should fix
that problem.