### PR TITLE
Added option for legacy (PHPCS v.1) processing

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -53,9 +53,9 @@ module.exports =
 
       # Determine if legacy mode needs to be set up (in case phpcs version = 1)
       helpers.exec(@command, ['--version']).then (result) =>
-        versionPattern = /^PHP_CodeSniffer version ([0-9]+)/i;
+        versionPattern = /^PHP_CodeSniffer version ([0-9]+)/i
         version = result.match versionPattern
-        if version && version[1] == '1'
+        if version and version[1] is '1'
           @legacy = true
     )
     @subscriptions.add atom.config.observe('linter-phpcs.disableWhenNoConfigFile', (value) =>

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -105,10 +105,12 @@ module.exports =
         confFile = helpers.findFile(path.dirname(filePath), ['phpcs.xml', 'phpcs.ruleset.xml'])
         standard = if @autoConfigSearch and confFile then confFile else standard
         legacy = @legacy
+        execprefix = ''
         return [] if @disableWhenNoConfigFile and not confFile
         if standard then parameters.push("--standard=#{standard}")
         parameters.push('--report=json')
-        if legacy then text = textEditor.getText() else text = 'phpcs_input_file: ' + filePath + eolChar + textEditor.getText()
+        execprefix = 'phpcs_input_file: ' + filePath + eolChar unless legacy
+        text = execprefix + textEditor.getText()
         return helpers.exec(command, parameters, {stdin: text}).then (result) ->
           try
             result = JSON.parse(result.toString().trim())


### PR DESCRIPTION
PHPCS v.1 is still used in some systems like Drupal or Joomla, and it doesn't support the phpcs_input_file option when processing phpcs command

This pull requests adds an optional "legacy" flag (default false) to support legacy phpcs v.1 so those systems can be checked with this linter