### PR TITLE
Fix forcing the line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=lf
+* text eol=lf


### PR DESCRIPTION
A mistake in the formatting of the .gitattributes meant it was being ignored.