### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "atom-linter": "^4.5.1",
+    "atom-linter": "^4.6.1",
     "atom-package-deps": "^4.0.1",
     "minimatch": "^3.0.0"
   },
   "devDependencies": {
     "coffeelint": "^1.14.2",
     "eslint": "^2.2.0",
-    "eslint-config-airbnb": "^6.0.1"
+    "eslint-config-airbnb": "^6.0.2"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
`atom-linter@4.6.1` brings in a 10 second timeout after which `phpcs` is automatically killed.

Fixes #78.