### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ linter-phpcs
 [![apm](https://img.shields.io/apm/v/linter-phpcs.svg)](https://atom.io/packages/linter-phpcs)
 [![apm](https://img.shields.io/apm/dm/linter-phpcs.svg)](https://atom.io/packages/linter-phpcs)
 
-This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides
+This linter plugin for [Linter](https://github.com/steelbrain/linter) provides
 an interface to [phpcs](http://pear.php.net/package/PHP_CodeSniffer/). It will
 be used with files that have the "PHP" and "HTML" syntax.
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/AtomLinter/Linter | https://github.com/steelbrain/linter 
