### PR TITLE
Use config file's directory as cwd

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -116,7 +116,9 @@ module.exports =
         parameters.push('--report=json')
         execprefix = 'phpcs_input_file: ' + filePath + eolChar unless legacy
         text = execprefix + textEditor.getText()
-        return helpers.exec(command, parameters, {stdin: text}).then (result) ->
+        execOptions = {stdin: text}
+        if confFile then execOptions.cwd = path.dirname(confFile)
+        return helpers.exec(command, parameters, execOptions).then (result) ->
           try
             result = JSON.parse(result.toString().trim())
           catch error


### PR DESCRIPTION
This PR sets the cwd of CodeSniffer to the directory it found a config file in.  If no config file is found it'll use the current behaviour. This solves issues with relative paths in the config file which, without the cwd, will be resolved from `/`.

As an example we have the following in our project's `phpcs.xml.dist` to use a coding standard that's not shipped with CodeSniffer;

```xml
<config name="installed_paths" value="vendor/escapestudios/symfony2-coding-standard" />
```

When running CodeSniffer from the terminal or through a git hook it works just fine but in the linter it complains that it can't find the coding standard Symfony2 (which is defined in the configured path). Adding the config file's directory as the linter's cwd fixes this issue and it behaves the same way as in the terminal.