### PR TITLE
fix underlined error when using tabs

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -150,8 +150,10 @@ module.exports =
             return [] unless result.files[filePath]
             messages = result.files[filePath].messages
           return messages.map (message) =>
-            startPoint = [message.line - 1, message.column - 1]
-            endPoint = [message.line - 1, message.column]
+            screenPosition = textEditor.screenPositionForBufferPosition([message.line - 1, 0])
+            bufferPosition = textEditor.bufferPositionForScreenPosition([screenPosition.row, message.column - 1])
+            startPoint = [bufferPosition.row, bufferPosition.column]
+            endPoint = [bufferPosition.row, bufferPosition.column + 1]
             ret = {
               type: message.type
               filePath,


### PR DESCRIPTION
message.column is the screen column but linter thinks we are returning the buffer column. We need to get the screen row before we get the buffer column incase they have any code folded then we get the buffer position from the screen position.

fixes #146