### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 env:
   global:
     - COMPOSER_DISABLE_XDEBUG_WARN="1"
-    - secure: "JmA5S4tIX7Mkt3VI4CZyi4sP8xt/SLXC2RwRkLLuuLWfMOSzQ9jSFiAi64XK/QYZI3Sc0thbA7+ZTxbEm92saHMQk7b7ktyFHZfVUBExMHBxrWf+wmUNUi1ldPkZQydQ9xgfoWcgusuVrjcJ9stvW23vCkbl5jSHGeWkAzH8DG0="
+    - COMPOSER_OAUTH_TOKEN="cc4a091c096e7d3cfe053c3f669fb840be60ab98"
 
 matrix:
   include:
@@ -50,7 +50,10 @@ before_script:
   - phpcs --version
 
 ### Generic setup follows ###
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 notifications:
   email:

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,12 @@
 test:
   override:
     - phpcs --version
-    - curl -s https://raw.githubusercontent.com/Arcanemagus/ci/atomlinter/build-package.sh | sh
+    - ./build-package.sh
 
 dependencies:
   override:
+    - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+    - chmod u+x build-package.sh
     - composer config -g github-oauth.github.com cc4a091c096e7d3cfe053c3f669fb840be60ab98
     - composer global require "squizlabs/php_codesniffer=*"
 


### PR DESCRIPTION
* Fixes from atom/ci to how the script is downloaded
* Stop using a secure key in Travis-CI, none of the other CI platforms are
  using it and it breaks for external PRs.