### PR TITLE
Version updates

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -203,7 +203,7 @@ export default {
         let text;
         if (version.major >= 3 || (version.major === 2 && version.minor >= 6)) {
           // PHPCS 2.6 and above support sending the filename in a flag
-          parameters.push(`--stdin-path=${filePath}`);
+          parameters.push(`--stdin-path="${filePath}"`);
           text = fileText;
         } else if ((version.major === 2 && version.minor < 6) || version.major < 2) {
           // PHPCS 2.x.x before 2.6.0 supports putting the name in the start of the stream
@@ -257,7 +257,12 @@ export default {
         }
 
         let messages;
-        if (version.major > 1) {
+        if (version.major >= 3 || (version.major === 2 && version.minor >= 6)) {
+          if (!data.files[`"${filePath}"`]) {
+            return [];
+          }
+          messages = data.files[`"${filePath}"`].messages;
+        } else if (version.major === 2 && version.minor < 6) {
           if (!data.files[filePath]) {
             return [];
           }

--- a/lib/main.js
+++ b/lib/main.js
@@ -168,7 +168,6 @@ export default {
         const parameters = ['--report=json'];
         // Get the version of the chosen PHPCS
         const version = await getPHPCSVersion(executablePath);
-        const legacy = version.major < 2;
 
         // Check if file should be ignored
         if (version.major > 2) {
@@ -194,9 +193,21 @@ export default {
           parameters.push('-s');
         }
 
-        const eolChar = textEditor.getBuffer().lineEndingForRow(0);
-        const execPrefix = !legacy ? `phpcs_input_file: ${filePath}${eolChar}` : '';
-        const text = execPrefix + fileText;
+        // Determine the method of setting the file name
+        let text;
+        if (version.major >= 3 || (version.major === 2 && version.minor >= 6)) {
+          // PHPCS 2.6 and above support sending the filename in a flag
+          parameters.push(`--stdin-path=${filePath}`);
+          text = fileText;
+        } else if ((version.major === 2 && version.minor < 6) || version.major < 2) {
+          // PHPCS 2.x.x before 2.6.0 supports putting the name in the start of the stream
+          const eolChar = textEditor.getBuffer().lineEndingForRow(0);
+          text = `phpcs_input_file: ${filePath}${eolChar}${fileText}`;
+        } else {
+          // PHPCS v1 supports stdin, but ignores all filenames
+          text = fileText;
+        }
+
 
         // Run PHPCS from the project root, or if not in a project the file directory
         let projectPath = atom.project.relativizePath(filePath)[0];

--- a/lib/main.js
+++ b/lib/main.js
@@ -238,16 +238,17 @@ export default {
         }
 
         let messages;
-        if (legacy) {
-          if (!data.files.STDIN) {
-            return [];
-          }
-          messages = data.files.STDIN.messages;
-        } else {
+        if (version.major > 1) {
           if (!data.files[filePath]) {
             return [];
           }
           messages = data.files[filePath].messages;
+        } else {
+          // PHPCS v1 can't associate a filename with STDIN input
+          if (!data.files.STDIN) {
+            return [];
+          }
+          messages = data.files.STDIN.messages;
         }
 
         return messages.map((message) => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -146,6 +146,11 @@ export default {
         const fileText = textEditor.getText();
         const fileDir = path.dirname(filePath);
 
+        if (fileText === '') {
+          // Empty file, empty results
+          return [];
+        }
+
         const parameters = ['--report=json'];
 
         // Check if a local PHPCS executable is available

--- a/lib/main.js
+++ b/lib/main.js
@@ -146,13 +146,7 @@ export default {
         const fileText = textEditor.getText();
         const fileDir = path.dirname(filePath);
 
-        // Check if a config file exists and handle it
-        const confFile = await helpers.findAsync(
-          fileDir, ['phpcs.xml', 'phpcs.xml.dist', 'phpcs.ruleset.xml', 'ruleset.xml']
-        );
-        if (disableWhenNoConfigFile && !confFile) {
-          return [];
-        }
+        const parameters = ['--report=json'];
 
         // Check if a local PHPCS executable is available
         if (autoExecutableSearch) {
@@ -165,7 +159,6 @@ export default {
           }
         }
 
-        const parameters = ['--report=json'];
         // Get the version of the chosen PHPCS
         const version = await getPHPCSVersion(executablePath);
 
@@ -179,6 +172,14 @@ export default {
           if (ignorePatterns.some(pattern => minimatch(baseName, pattern))) {
             return [];
           }
+        }
+
+        // Check if a config file exists and handle it
+        const confFile = await helpers.findAsync(fileDir,
+          ['phpcs.xml', 'phpcs.xml.dist', 'phpcs.ruleset.xml', 'ruleset.xml']
+        );
+        if (disableWhenNoConfigFile && !confFile) {
+          return [];
         }
 
         const standard = autoConfigSearch && confFile ? confFile : codeStandardOrConfigFile;

--- a/lib/main.js
+++ b/lib/main.js
@@ -208,6 +208,8 @@ export default {
           text = fileText;
         }
 
+        // Finish off the parameter list
+        parameters.push('-');
 
         // Run PHPCS from the project root, or if not in a project the file directory
         let projectPath = atom.project.relativizePath(filePath)[0];

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,7 +16,7 @@ let autoExecutableSearch;
 let disableWhenNoConfigFile;
 let codeStandardOrConfigFile;
 let autoConfigSearch;
-let ignore;
+let ignorePatterns;
 let errorsOnly;
 let warningSeverity;
 let tabWidth;
@@ -101,7 +101,7 @@ export default {
     );
     this.subscriptions.add(
       atom.config.observe('linter-phpcs.ignorePatterns', (value) => {
-        ignore = value;
+        ignorePatterns = value;
       })
     );
     this.subscriptions.add(
@@ -146,12 +146,6 @@ export default {
         const fileText = textEditor.getText();
         const fileDir = path.dirname(filePath);
 
-        // Check if file should be ignored
-        const baseName = path.basename(filePath);
-        if (ignore.some(pattern => minimatch(baseName, pattern))) {
-          return [];
-        }
-
         // Check if a config file exists and handle it
         const confFile = await helpers.findAsync(
           fileDir, ['phpcs.xml', 'phpcs.xml.dist', 'phpcs.ruleset.xml', 'ruleset.xml']
@@ -175,6 +169,18 @@ export default {
         // Get the version of the chosen PHPCS
         const version = await getPHPCSVersion(executablePath);
         const legacy = version.major < 2;
+
+        // Check if file should be ignored
+        if (version.major > 2) {
+          // PHPCS v3 and up support this with STDIN files
+          parameters.push(`--ignore=${ignorePatterns.join(',')}`);
+        } else {
+          // We must determine this ourself for lower versions
+          const baseName = path.basename(filePath);
+          if (ignorePatterns.some(pattern => minimatch(baseName, pattern))) {
+            return [];
+          }
+        }
 
         const standard = autoConfigSearch && confFile ? confFile : codeStandardOrConfigFile;
         if (standard) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,7 +8,7 @@ import minimatch from 'minimatch';
 import escapeHtml from 'escape-html';
 
 // Local variables
-const legacyExec = new Map();
+const execPathVersions = new Map();
 
 // Settings
 let executablePath;
@@ -23,20 +23,28 @@ let tabWidth;
 let showSource;
 let disableExecuteTimeout;
 
-const isLegacyExec = async (execPath) => {
-  // Determine if legacy mode needs to be set up (in case phpcs version = 1)
-  if (legacyExec.has(execPath)) {
-    return legacyExec.get(execPath);
-  }
+const determineExecVersion = async (execPath) => {
   const versionString = await helpers.exec(execPath, ['--version']);
-  const versionPattern = /^PHP_CodeSniffer version ([0-9]+)/i;
+  const versionPattern = /^PHP_CodeSniffer version (\d+)\.(\d+)\.(\d+)/i;
   const version = versionString.match(versionPattern);
-  if (version && version[1] === '1') {
-    legacyExec.set(execPath, true);
+  const ver = {};
+  if (version !== null) {
+    ver.major = Number.parseInt(version[1], 10);
+    ver.minor = Number.parseInt(version[2], 10);
+    ver.patch = Number.parseInt(version[3], 10);
   } else {
-    legacyExec.set(execPath, false);
+    ver.major = 0;
+    ver.minor = 0;
+    ver.patch = 0;
   }
-  return legacyExec.get(execPath);
+  execPathVersions.set(execPath, ver);
+};
+
+const getPHPCSVersion = async (execPath) => {
+  if (!execPathVersions.has(execPath)) {
+    await determineExecVersion(execPath);
+  }
+  return execPathVersions.get(execPath);
 };
 
 const fixPHPCSColumn = (textEditor, line, givenCol) => {
@@ -154,7 +162,7 @@ export default {
 
         // Check if a local PHPCS executable is available
         if (autoExecutableSearch) {
-          const executable = await helpers.findAsync(
+          const executable = await helpers.findCachedAsync(
             fileDir, ['vendor/bin/phpcs.bat', 'vendor/bin/phpcs']
           );
 
@@ -162,9 +170,11 @@ export default {
             executablePath = executable;
           }
         }
-        const legacy = await isLegacyExec(executablePath);
 
         const parameters = ['--report=json'];
+        // Get the version of the chosen PHPCS
+        const version = await getPHPCSVersion(executablePath);
+        const legacy = version.major < 2;
 
         const standard = autoConfigSearch && confFile ? confFile : codeStandardOrConfigFile;
         if (standard) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -187,7 +187,7 @@ export default {
           parameters.push(`--standard=${standard}`);
         }
         parameters.push(`--warning-severity=${errorsOnly ? 0 : warningSeverity}`);
-        if (tabWidth) {
+        if (tabWidth > 1) {
           parameters.push(`--tab-width=${tabWidth}`);
         }
         if (showSource) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -198,7 +198,14 @@ export default {
         const execPrefix = !legacy ? `phpcs_input_file: ${filePath}${eolChar}` : '';
         const text = execPrefix + fileText;
 
+        // Run PHPCS from the project root, or if not in a project the file directory
+        let projectPath = atom.project.relativizePath(filePath)[0];
+        if (projectPath === null) {
+          projectPath = fileDir;
+        }
+
         const execOptions = {
+          cwd: projectPath,
           stdin: text,
           ignoreExitCode: true,
         };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "codeStandardOrConfigFile": {
       "type": "string",
       "default": "PSR2",
-      "description": "Enter path to config file or a coding standard, PSR2 for example.",
+      "description": "Enter path to config file or a predefined coding standard name.",
       "order": 4
     },
     "disableWhenNoConfigFile": {

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -30,21 +30,21 @@ describe('The phpcs provider for Linter', () => {
 
   describe('checks bad.php and', () => {
     let editor = null;
-    beforeEach(() => {
+    beforeEach(() =>
       waitsForPromise(() =>
         atom.workspace.open(badPath).then((openEditor) => { editor = openEditor; })
-      );
-    });
+      )
+    );
 
-    it('finds at least one message', () => {
+    it('finds at least one message', () =>
       waitsForPromise(() =>
         lint(editor).then(messages =>
           expect(messages.length).toBeGreaterThan(0)
         )
-      );
-    });
+      )
+    );
 
-    it('verifies the first message', () => {
+    it('verifies the first message', () =>
       waitsForPromise(() =>
         lint(editor).then((messages) => {
           expect(messages[0].type).toBe('ERROR');
@@ -56,8 +56,8 @@ describe('The phpcs provider for Linter', () => {
           expect(messages[0].filePath).toBe(badPath);
           expect(messages[0].range).toEqual([[1, 5], [1, 9]]);
         })
-      );
-    });
+      )
+    );
   });
 
   describe('checks tabs.php and', () => {
@@ -69,15 +69,15 @@ describe('The phpcs provider for Linter', () => {
       );
     });
 
-    it('finds at least two messages', () => {
+    it('finds at least two messages', () =>
       waitsForPromise(() =>
         lint(editor).then(messages =>
           expect(messages.length).toBeGreaterThan(1)
         )
-      );
-    });
+      )
+    );
 
-    it('verifies the second message', () => {
+    it('verifies the second message', () =>
       waitsForPromise(() =>
         lint(editor).then((messages) => {
           expect(messages[1].type).toBe('ERROR');
@@ -89,23 +89,23 @@ describe('The phpcs provider for Linter', () => {
           expect(messages[1].filePath).toBe(tabsPath);
           expect(messages[1].range).toEqual([[2, 6], [2, 10]]);
         })
-      );
-    });
+      )
+    );
   });
 
-  it('finds nothing wrong with an empty file', () => {
+  it('finds nothing wrong with an empty file', () =>
     waitsForPromise(() =>
       atom.workspace.open(emptyPath).then(editor =>
         lint(editor).then(messages => expect(messages.length).toBe(0))
       )
-    );
-  });
+    )
+  );
 
-  it('finds nothing wrong with a valid file', () => {
+  it('finds nothing wrong with a valid file', () =>
     waitsForPromise(() =>
       atom.workspace.open(goodPath).then(editor =>
         lint(editor).then(messages => expect(messages.length).toBe(0))
       )
-    );
-  });
+    )
+  );
 });


### PR DESCRIPTION
Several bugfixes and updates for PHPCS versions since this was last worked on:

* Allow PHPCS to handle ignoring files if it is above version 3
* Specify the file name in the best manner available to each version
* Many minor fixes and refactors