### PR TITLE
Implement --exclude option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,6 +22,7 @@ let warningSeverity;
 let tabWidth;
 let showSource;
 let disableExecuteTimeout;
+let excludedSniffs;
 
 const determineExecVersion = async (execPath) => {
   const versionString = await helpers.exec(execPath, ['--version']);
@@ -129,6 +130,11 @@ export default {
         disableExecuteTimeout = value;
       })
     );
+    this.subscriptions.add(
+      atom.config.observe('linter-phpcs.excludedSniffs', (value) => {
+        excludedSniffs = value;
+      })
+    );
   },
 
   deactivate() {
@@ -197,6 +203,15 @@ export default {
         }
         if (showSource) {
           parameters.push('-s');
+        }
+
+        // Ignore any requested Sniffs
+        if (excludedSniffs.length > 0 && (
+          version.major > 2 ||
+          (version.major === 2 && version.minor > 6) ||
+          (version.major === 2 && version.minor === 6 && version.patch > 1)
+        )) {
+          parameters.push(`--exclude=${excludedSniffs.join(',')}`);
         }
 
         // Determine the method of setting the file name

--- a/package.json
+++ b/package.json
@@ -83,6 +83,14 @@
       "default": true,
       "description": "Show source in message.",
       "order": 11
+    },
+    "excludedSniffs": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      },
+      "description": "Command separated list of Sniffs to ignore. Ignored below PHPCS v2.6.2."
     }
   },
   "dependencies": {

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -36,17 +36,10 @@ describe('The phpcs provider for Linter', () => {
       )
     );
 
-    it('finds at least one message', () =>
-      waitsForPromise(() =>
-        lint(editor).then(messages =>
-          expect(messages.length).toBeGreaterThan(0)
-        )
-      )
-    );
-
-    it('verifies the first message', () =>
+    it('verifies the results', () =>
       waitsForPromise(() =>
         lint(editor).then((messages) => {
+          expect(messages.length).toBe(1);
           expect(messages[0].type).toBe('ERROR');
           expect(messages[0].text).not.toBeDefined();
           expect(messages[0].html).toBe('' +
@@ -108,4 +101,16 @@ describe('The phpcs provider for Linter', () => {
       )
     )
   );
+
+  it('allows specifying sniffs to ignore', () => {
+    atom.config.set('linter-phpcs.excludedSniffs', ['Generic.PHP.LowerCaseConstant']);
+    waitsForPromise(() =>
+      atom.workspace.open(badPath).then(editor =>
+        lint(editor).then(messages =>
+          // Note that we have earlier checked that it should be 1 normally
+          expect(messages.length).toBe(0)
+        )
+      )
+    );
+  });
 });


### PR DESCRIPTION
Added in PHPCS v2.6.2, ignored when running a version below that.
Fixes #168.