### PR TITLE
Enable support for JS and CSS

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,7 @@ import escapeHtml from 'escape-html';
 
 // Local variables
 const execPathVersions = new Map();
+const grammarScopes = ['source.php'];
 
 // Settings
 let executablePath;
@@ -67,6 +68,14 @@ const fixPHPCSColumn = (textEditor, line, givenCol) => {
     }
   }
   return column;
+};
+
+const scopeAvailable = (scope, available) => {
+  if (available === false && grammarScopes.includes(scope)) {
+    grammarScopes.splice(grammarScopes.indexOf(scope), 1);
+  } else if (available === true && !grammarScopes.includes(scope)) {
+    grammarScopes.push(scope);
+  }
 };
 
 export default {
@@ -135,6 +144,16 @@ export default {
         excludedSniffs = value;
       })
     );
+    this.subscriptions.add(
+      atom.config.observe('linter-phpcs.otherLanguages.useCSSTools', (value) => {
+        scopeAvailable('source.css', value);
+      })
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-phpcs.otherLanguages.useJSTools', (value) => {
+        scopeAvailable('source.js', value);
+      })
+    );
   },
 
   deactivate() {
@@ -144,7 +163,7 @@ export default {
   provideLinter() {
     return {
       name: 'PHPCS',
-      grammarScopes: ['source.php'],
+      grammarScopes,
       scope: 'file',
       lintOnFly: true,
       lint: async (textEditor) => {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "atom": ">=1.4.0 <2.0.0"
+    "atom": ">=1.8.0 <2.0.0"
   },
   "configSchema": {
     "executablePath": {
@@ -90,7 +90,28 @@
       "items": {
         "type": "string"
       },
-      "description": "Command separated list of Sniffs to ignore. Ignored below PHPCS v2.6.2."
+      "description": "Command separated list of Sniffs to ignore. Ignored below PHPCS v2.6.2.",
+      "order": 12
+    },
+    "otherLanguages": {
+      "type": "object",
+      "collapsed": true,
+      "description": "If properly configured, PHPCS can run external tools to lint languages other than PHP. Only enable the below options if you have set this up.",
+      "order": 13,
+      "properties": {
+        "useCSSTools": {
+          "title": "Enable CSS Tools",
+          "description": "Enable sending CSS files to configured tools. **Requires configuration**",
+          "type": "boolean",
+          "default": false
+        },
+        "useJSTools": {
+          "title": "Enable JS Tools",
+          "description": "Enable sending JS files to configured tools. **Requires configuration**",
+          "type": "boolean",
+          "default": false
+        }
+      }
     }
   },
   "dependencies": {


### PR DESCRIPTION
For some bizarre reason PHPCS [supports](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Configuration-Options#setting-the-path-to-csslint) sending CSS and JS files on to other external tools. It has been requested that this linter support this, even though it is a much better idea to use the Linter providers dedicated to those tools. Setting this up to be tested is rather difficult, so no specs are provided.

Closes #113.