### PR TITLE
Display original message with errors

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -318,10 +318,29 @@ export default {
           }
           column -= 1;
 
+          let range;
+          try {
+            range = helpers.rangeFromLineNumber(textEditor, line, column);
+          } catch (e) {
+            const lineText = textEditor.getBuffer().lineForRow(line);
+            // eslint-disable-next-line no-console
+            console.error(
+              'linter-phpcs:: Invalid point encountered in the attached message',
+              {
+                message,
+                source: {
+                  lineLength: lineText.length,
+                  lineText,
+                },
+              }
+            );
+            throw Error('Invalid point encountered! See console for details.');
+          }
+
           const msg = {
             type: message.type,
             filePath,
-            range: helpers.rangeFromLineNumber(textEditor, line, column),
+            range,
           };
 
           if (showSource) {


### PR DESCRIPTION
When an invalid point is encountered, display the original message in the
console for easier debugging.