### PR TITLE
Default tabs to 4 characters

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -49,22 +49,22 @@ const getPHPCSVersion = async (execPath) => {
   return execPathVersions.get(execPath);
 };
 
-const fixPHPCSColumn = (textEditor, line, givenCol) => {
-  const lineText = textEditor.lineTextForBufferRow(line);
+const fixPHPCSColumn = (lineText, line, givenCol) => {
+  // Almost all PHPCS sniffs default to replacing tabs with 4 spaces
+  // This is horribly wrong, but that's how it works currently
+  const tabLength = tabWidth > 0 ? tabWidth : 4;
   let column = givenCol;
-  if (lineText.includes('\t')) {
-    let screenCol = 0;
-    for (let col = 0; col < lineText.length; col += 1) {
-      const char = lineText[col];
-      if (char === '\t') {
-        screenCol += tabWidth - (screenCol % tabWidth);
-      } else {
-        screenCol += 1;
-      }
-      if (screenCol >= column) {
-        column = col + 1;
-        break;
-      }
+  let screenCol = 0;
+  for (let col = 0; col < lineText.length; col += 1) {
+    const char = lineText[col];
+    if (char === '\t') {
+      screenCol += tabLength - (screenCol % tabLength);
+    } else {
+      screenCol += 1;
+    }
+    if (screenCol >= column) {
+      column = col + 1;
+      break;
     }
   }
   return column;
@@ -313,8 +313,10 @@ export default {
           // fix column in line with tabs
           let { line, column } = message;
           line -= 1;
-          if (tabWidth > 1) {
-            column = fixPHPCSColumn(textEditor, line, column);
+          const lineText = textEditor.getBuffer().lineForRow(line);
+
+          if (lineText.includes('\t')) {
+            column = fixPHPCSColumn(lineText, line, column);
           }
           column -= 1;
 
@@ -322,7 +324,6 @@ export default {
           try {
             range = helpers.rangeFromLineNumber(textEditor, line, column);
           } catch (e) {
-            const lineText = textEditor.getBuffer().lineForRow(line);
             // eslint-disable-next-line no-console
             console.error(
               'linter-phpcs:: Invalid point encountered in the attached message',

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tabWidth": {
       "type": "integer",
       "default": 0,
-      "description": "Set the number of spaces that tab characters represent to the linter. Enter 0 to disable this option.",
+      "description": "Set the number of spaces that tab characters represent to the linter. Will use 4 if set to 0 as most PHPCS sniffs have that as a hidden default.",
       "order": 10
     },
     "showSource": {


### PR DESCRIPTION
Although the documentation claims otherwise, it seems most PHPCS sniffs will default tabs to 4 characters by default. If the user hasn't set an override of their own we now use 4.

Fixes #204.