### PR TITLE
Allow Folder or Fullpath exclusions using Ignore Patterns

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -196,6 +196,8 @@ export default {
         if (version.major > 2) {
           // PHPCS v3 and up support this with STDIN files
           parameters.push(`--ignore=${ignorePatterns.join(',')}`);
+
+          // We must determine this ourself for lower versions
         } else if (ignorePatterns.some(pattern => minimatch(filePath, pattern))) {
           return [];
         }

--- a/lib/main.js
+++ b/lib/main.js
@@ -196,18 +196,8 @@ export default {
         if (version.major > 2) {
           // PHPCS v3 and up support this with STDIN files
           parameters.push(`--ignore=${ignorePatterns.join(',')}`);
-        } else {
-          // We must determine this ourself for lower versions
-          const fileList = [
-            path.basename(filePath),
-            path.dirname(filePath),
-            filePath,
-          ];
-
-          // Check the patterns against File Name, Directory Path, Full Path
-          if (ignorePatterns.some(pattern => minimatch.match(fileList, pattern).length > 0)) {
-            return [];
-          }
+        } else if (ignorePatterns.some(pattern => minimatch(filePath, pattern))) {
+          return [];
         }
 
         // Check if a config file exists and handle it

--- a/lib/main.js
+++ b/lib/main.js
@@ -196,9 +196,8 @@ export default {
         if (version.major > 2) {
           // PHPCS v3 and up support this with STDIN files
           parameters.push(`--ignore=${ignorePatterns.join(',')}`);
-
-          // We must determine this ourself for lower versions
         } else if (ignorePatterns.some(pattern => minimatch(filePath, pattern))) {
+          // We must determine this ourself for lower versions
           return [];
         }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -199,9 +199,11 @@ export default {
         } else {
           // We must determine this ourself for lower versions
           const baseName = path.basename(filePath);
-          if (ignorePatterns.some(pattern => minimatch(baseName, pattern))) {
-            return [];
-          }
+          const dirName = path.dirname(filePath);
+
+          if (ignorePatterns.some(pattern => {
+              return minimatch(baseName, pattern) || minimatch(dirName, pattern) || minimatch(filePath, pattern);
+            })) return [];
         }
 
         // Check if a config file exists and handle it

--- a/lib/main.js
+++ b/lib/main.js
@@ -198,14 +198,16 @@ export default {
           parameters.push(`--ignore=${ignorePatterns.join(',')}`);
         } else {
           // We must determine this ourself for lower versions
-          const baseName = path.basename(filePath);
-          const dirName = path.dirname(filePath);
+          const fileList = [
+            path.basename(filePath),
+            path.dirname(filePath),
+            filePath,
+          ];
 
-          if (ignorePatterns.some((pattern) => {
-            return minimatch(baseName, pattern) ||
-              minimatch(dirName, pattern) ||
-              minimatch(filePath, pattern);
-          })) return [];
+          // Check the patterns against File Name, Directory Path, Full Path
+          if (ignorePatterns.some(pattern => minimatch.match(fileList, pattern).length > 0)) {
+            return [];
+          }
         }
 
         // Check if a config file exists and handle it

--- a/lib/main.js
+++ b/lib/main.js
@@ -201,9 +201,11 @@ export default {
           const baseName = path.basename(filePath);
           const dirName = path.dirname(filePath);
 
-          if (ignorePatterns.some(pattern => {
-              return minimatch(baseName, pattern) || minimatch(dirName, pattern) || minimatch(filePath, pattern);
-            })) return [];
+          if (ignorePatterns.some((pattern) => {
+            return minimatch(baseName, pattern) ||
+              minimatch(dirName, pattern) ||
+              minimatch(filePath, pattern);
+          })) return [];
         }
 
         // Check if a config file exists and handle it

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Enter filename patterns to ignore when running the linter.",
+      "description": "Enter Glob patterns to ignore when running the linter.",
       "order": 7
     },
     "displayErrorsOnly": {


### PR DESCRIPTION
This will allow excluding a Folder or a Fullpath while running the linter, existing file exclusions still work. 

As the package always runs the `phpcs` command against a single file, the `<exclude-pattern>` in the `phpcs.xml` file was not working. This way the a folder can be excluded from the linter. Glob example for folders would be `/**/foldername/*`