### PR TITLE
Fix default ignore patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "ignorePatterns": {
       "type": "array",
       "default": [
-        "*.blade.php",
-        "*.twig.php"
+        "**/*.blade.php",
+        "**/*.twig.php"
       ],
       "items": {
         "type": "string"


### PR DESCRIPTION
The previous ignore patterns don't work for the fallback minimatch used when the current PHPCS is too old. These new patterns should work for the fallback as well as the method built into PHPCS v3.

Fixes #213.