### PR TITLE
Use '-q' when phpcs supports it

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -193,10 +193,10 @@ export default {
         const version = await getPHPCSVersion(executablePath);
 
         // -q (quiet) option is available since phpcs 2.6.2
-        if (version.major > 2 
-          || (version.major == 2 && version.minor > 6)
-          || (version.major == 2 && version.minor == 6 && version.patch >= 2)
-		) {
+        if (version.major > 2
+          || (version.major === 2 && version.minor > 6)
+          || (version.major === 2 && version.minor === 6 && version.patch >= 2)
+        ) {
           parameters.push('-q');
         }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -192,6 +192,14 @@ export default {
         // Get the version of the chosen PHPCS
         const version = await getPHPCSVersion(executablePath);
 
+        // -q (quiet) option is available since phpcs 2.6.2
+        if (version.major > 2 
+          || (version.major == 2 && version.minor > 6)
+          || (version.major == 2 && version.minor == 6 && version.patch >= 2)
+		) {
+          parameters.push('-q');
+        }
+
         // Check if file should be ignored
         if (version.major > 2) {
           // PHPCS v3 and up support this with STDIN files


### PR DESCRIPTION
This forces phpcs to not print neither totals nor progress even if config
specifies -p (progress) option. Will work with phpcs 2.6.2 and newer.

Several people reported problems with superfluous phpcs output, see
AtomLinter/linter-phpcs#95 and AtomLinter/linter-phpcs#144.