### PR TITLE
Added --encoding option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -200,6 +200,13 @@ export default {
           parameters.push('-q');
         }
 
+        // --encoding is available since 1.3.0 (RC1, but we ignore that for simplicity)
+        if (version.major > 1
+          || (version.major === 1 && version.minor >= 3)
+        ) {
+          parameters.push(`--encoding=${textEditor.getBuffer().getEncoding()}`);
+        }
+
         // Check if file should be ignored
         if (version.major > 2) {
           // PHPCS v3 and up support this with STDIN files


### PR DESCRIPTION
This adds --encoding option when phpcs supports it. Currently no
encoding name translation is done, might be required down the road.

Fixes AtomLinter/linter-phpcs#227
Fixes AtomLinter/linter-phpcs#211
_Note: Edited by @arcanemagus so GH will close the related issues automatically._