### PR TITLE
Fix composer PATH and disable XDebug warning

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,3 +13,6 @@ dependencies:
 machine:
   php:
     version: 7.0.4
+  environment:
+    COMPOSER_DISABLE_XDEBUG_WARN: 1
+    PATH: "$HOME/.config/composer/vendor/bin:$PATH"

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ dependencies:
   override:
     - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
     - chmod u+x build-package.sh
+    - composer --version
     - composer config -g github-oauth.github.com cc4a091c096e7d3cfe053c3f669fb840be60ab98
     - composer global require "squizlabs/php_codesniffer=*"
 

--- a/circle.yml
+++ b/circle.yml
@@ -16,4 +16,4 @@ machine:
     version: 7.0.4
   environment:
     COMPOSER_DISABLE_XDEBUG_WARN: 1
-    PATH: "$HOME/.config/composer/vendor/bin:$PATH"
+    COMPOSER_HOME: "/home/ubuntu/.composer"


### PR DESCRIPTION
It seems that current versions of `composer` have changed where they store the binary files, but the CircleCI environment hasn't been updated to account for this as far as the $PATH is concerned.