### PR TITLE
Error: Invalid point encountered - consistently with PHPCS 1.x

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -251,7 +251,7 @@ export default {
           // PHPCS 2.6 and above support sending the filename in a flag
           parameters.push(`--stdin-path="${filePath}"`);
           text = fileText;
-        } else if ((version.major === 2 && version.minor < 6) || version.major < 2) {
+        } else if (version.major === 2 && version.minor < 6) {
           // PHPCS 2.x.x before 2.6.0 supports putting the name in the start of the stream
           const eolChar = textEditor.getBuffer().lineEndingForRow(0);
           text = `phpcs_input_file: ${filePath}${eolChar}${fileText}`;


### PR DESCRIPTION
Hi,

Looks like with PHPCS 1.x all of the line numbers are off by one, which consistently causes invalid point encountered, especially for long lines. I've tested this fix and it fixes the issue. Seems the filename was being specified in STDIN but only PHP 2.0, <2.6 supports this, so for PHPCS 1.x it just throws off the line number by 1 for every single error.

Thanks

Jason