### PR TITLE
Update atom-linter to v9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     }
   },
   "dependencies": {
-    "atom-linter": "^9.0.0",
+    "atom-linter": "^9.0.1",
     "atom-package-deps": "^4.0.1",
     "escape-html": "^1.0.3",
     "minimatch": "^3.0.2"


### PR DESCRIPTION
Brings in a restoration of the 10 second timeout on running `phpcs`.

Fixes #237.
Fixes #239.
Closes #241.