### PR TITLE
Upgraded to Linter v2 and updated the code to the new API.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,6 @@ import { CompositeDisposable } from 'atom';
 import * as helpers from 'atom-linter';
 import path from 'path';
 import minimatch from 'minimatch';
-import escapeHtml from 'escape-html';
 
 // Local variables
 const execPathVersions = new Map();
@@ -165,7 +164,7 @@ export default {
       name: 'PHPCS',
       grammarScopes,
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
         const fileText = textEditor.getText();
@@ -353,16 +352,17 @@ export default {
           }
 
           const msg = {
-            type: message.type,
-            filePath,
-            range,
+            severity: message.type.toLowerCase(),
+            location: {
+              file: filePath,
+              position: range,
+            },
           };
 
           if (showSource) {
-            msg.html = `<span class="badge badge-flexible">${message.source || 'Unknown'}</span> `;
-            msg.html += escapeHtml(message.message);
+            msg.excerpt = `[${message.source || 'Unknown'}] ${message.message}`;
           } else {
-            msg.text = message.message;
+            msg.excerpt = message.message;
           }
 
           return msg;

--- a/lib/main.js
+++ b/lib/main.js
@@ -333,9 +333,9 @@ export default {
           }
           column -= 1;
 
-          let range;
+          let position;
           try {
-            range = helpers.generateRange(textEditor, line, column);
+            position = helpers.generateRange(textEditor, line, column);
           } catch (e) {
             // eslint-disable-next-line no-console
             console.error(
@@ -355,7 +355,7 @@ export default {
             severity: message.type.toLowerCase(),
             location: {
               file: filePath,
-              position: range,
+              position,
             },
           };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -351,8 +351,19 @@ export default {
             throw Error('Invalid point encountered! See console for details.');
           }
 
+          let severity;
+
+          if (message.type) {
+            severity = message.type.toLowerCase();
+          }
+
+          // severity can only be one of these options
+          if (!['error', 'warning', 'info'].includes(severity)) {
+            severity = 'warning';
+          }
+
           const msg = {
-            severity: message.type.toLowerCase(),
+            severity,
             location: {
               file: filePath,
               position,

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   },
   "dependencies": {
     "atom-linter": "^9.0.1",
-    "atom-package-deps": "^4.0.1",
+    "atom-package-deps": "^4.5.0",
     "minimatch": "^3.0.2"
   },
   "devDependencies": {
@@ -125,7 +125,7 @@
     "eslint-plugin-import": "^2.2.0"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "scripts": {
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
   "dependencies": {
     "atom-linter": "^9.0.1",
     "atom-package-deps": "^4.0.1",
-    "escape-html": "^1.0.3",
     "minimatch": "^3.0.2"
   },
   "devDependencies": {
@@ -135,7 +134,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -42,14 +42,14 @@ describe('The phpcs provider for Linter', () => {
       waitsForPromise(() =>
         lint(editor).then((messages) => {
           expect(messages.length).toBe(1);
-          expect(messages[0].type).toBe('ERROR');
-          expect(messages[0].text).not.toBeDefined();
-          expect(messages[0].html).toBe('' +
-            '<span class="badge badge-flexible">Generic.PHP.LowerCaseConstant.Found</span>' +
+          expect(messages[0].severity).toBe('error');
+          expect(messages[0].description).not.toBeDefined();
+          expect(messages[0].excerpt).toBe('' +
+            '[Generic.PHP.LowerCaseConstant.Found]' +
             ' TRUE, FALSE and NULL must be lowercase; ' +
-            'expected &quot;true&quot; but found &quot;TRUE&quot;');
-          expect(messages[0].filePath).toBe(badPath);
-          expect(messages[0].range).toEqual([[1, 5], [1, 9]]);
+            'expected "true" but found "TRUE"');
+          expect(messages[0].location.file).toBe(badPath);
+          expect(messages[0].location.position).toEqual([[1, 5], [1, 9]]);
         }),
       ),
     );
@@ -74,7 +74,7 @@ describe('The phpcs provider for Linter', () => {
       waitsForPromise(() =>
         lint(editor).then((messages) => {
           expect(messages.length).toBe(1);
-          expect(messages[0].html).toMatch(/Line exceeds/);
+          expect(messages[0].excerpt).toMatch(/Line exceeds/);
         }),
       );
     });
@@ -124,14 +124,14 @@ describe('The phpcs provider for Linter', () => {
     it('verifies the second message', () =>
       waitsForPromise(() =>
         lint(editor).then((messages) => {
-          expect(messages[1].type).toBe('ERROR');
-          expect(messages[1].text).not.toBeDefined();
-          expect(messages[1].html).toBe('' +
-            '<span class="badge badge-flexible">Generic.PHP.LowerCaseConstant.Found</span>' +
+          expect(messages[1].severity).toBe('error');
+          expect(messages[1].description).not.toBeDefined();
+          expect(messages[1].excerpt).toBe('' +
+            '[Generic.PHP.LowerCaseConstant.Found]' +
             ' TRUE, FALSE and NULL must be lowercase; ' +
-            'expected &quot;true&quot; but found &quot;TRUE&quot;');
-          expect(messages[1].filePath).toBe(tabsPath);
-          expect(messages[1].range).toEqual([[2, 6], [2, 10]]);
+            'expected "true" but found "TRUE"');
+          expect(messages[1].location.file).toBe(tabsPath);
+          expect(messages[1].location.position).toEqual([[2, 6], [2, 10]]);
         }),
       ),
     );


### PR DESCRIPTION
Recently the linter package version 2.0.0 has been launched. And one of the changes is the new linter-ui-default package with the new default ui for the linter.

linter-phpcs became really hard to read with this new theme, so I upgraded the package and the code to the new API and removed the HTML badge (the new API don't allow HTML and instead recommends Markdown on the 'description' property).