### PR TITLE
Remove unnecessary quotes in --stdin-path option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -250,7 +250,7 @@ export default {
         let text;
         if (version.major >= 3 || (version.major === 2 && version.minor >= 6)) {
           // PHPCS 2.6 and above support sending the filename in a flag
-          parameters.push(`--stdin-path="${filePath}"`);
+          parameters.push(`--stdin-path=${filePath}`);
           text = fileText;
         } else if (version.major === 2 && version.minor < 6) {
           // PHPCS 2.x.x before 2.6.0 supports putting the name in the start of the stream
@@ -304,12 +304,7 @@ export default {
         }
 
         let messages;
-        if (version.major >= 3 || (version.major === 2 && version.minor >= 6)) {
-          if (!data.files[`"${filePath}"`]) {
-            return [];
-          }
-          messages = data.files[`"${filePath}"`].messages;
-        } else if (version.major === 2 && version.minor < 6) {
+        if (version.major >= 2 ) {
           if (!data.files[filePath]) {
             return [];
           }

--- a/lib/main.js
+++ b/lib/main.js
@@ -304,7 +304,7 @@ export default {
         }
 
         let messages;
-        if (version.major >= 2 ) {
+        if (version.major >= 2) {
           if (!data.files[filePath]) {
             return [];
           }


### PR DESCRIPTION
Arguments passed to childProcess don't need to be quoted, and if quotes are present, they're passed as literal quote characters. Previously, PHPCS was interpreting the quotes in `--stdin-path` as part of the name of the file being edited.

I have tested this on Mac OS 10.12.4, including for files with spaces in their names, and it works A-OK; no errors, and when I use the WordPress coding standards, they no longer complain about class files being named incorrectly (see #248).

It seems like this problem only comes up when using the WordPress coding standards; I'm guessing none of the more, uh, "standard" standards expect the whole filename to match a specific string. So to properly test this, I think the Travis script will need to be modified to install the WordPress standards so they can be used in the package specs. I can probably do that in the next week or so, but that'll be unfamiliar territory for me, so please bear with me. :)