### PR TITLE
Fix `Invalid point encountered!` when using tabs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -65,6 +65,9 @@ const fixPHPCSColumn = (lineText, line, givenCol) => {
       break;
     }
   }
+  if (column > lineText.length) {
+    column = lineText.length;
+  }
   return column;
 };
 

--- a/spec/files/tabs.php
+++ b/spec/files/tabs.php
@@ -1,4 +1,5 @@
 <?php
 if (true) {
 	$a = TRUE;
+	$b = "A very very very very very very very very very very very very very very very very very very very very long string.";
 }

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -135,6 +135,19 @@ describe('The phpcs provider for Linter', () => {
         }),
       ),
     );
+
+    it('verifies the position when tabWidth = 2', () =>
+      waitsForPromise(() => {
+        atom.config.set('linter-phpcs.tabWidth', 2);
+        return lint(editor).then((messages) => {
+          expect(messages[3].excerpt).toBe('' +
+            '[Generic.Files.LineLength.TooLong]' +
+            ' Line exceeds 120 characters; ' +
+            'contains 126 characters');
+          expect(messages[3].location.position).toEqual([[3, 122], [3, 123]]);
+        });
+      }),
+    );
   });
 
   it('finds nothing wrong with an empty file', () =>

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -139,12 +139,29 @@ describe('The phpcs provider for Linter', () => {
     it('verifies the position when tabWidth = 2', () =>
       waitsForPromise(() => {
         atom.config.set('linter-phpcs.tabWidth', 2);
+        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PEAR');
         return lint(editor).then((messages) => {
-          expect(messages[3].excerpt).toBe('' +
+          const lastMessage = messages[messages.length - 1];
+          expect(lastMessage.excerpt).toBe('' +
             '[Generic.Files.LineLength.TooLong]' +
-            ' Line exceeds 120 characters; ' +
-            'contains 126 characters');
-          expect(messages[3].location.position).toEqual([[3, 122], [3, 123]]);
+            ' Line exceeds 85 characters; ' +
+            'contains 124 characters');
+          expect(lastMessage.location.position).toEqual([[3, 122], [3, 123]]);
+        });
+      }),
+    );
+
+    it('verifies the position when tabWidth = 6', () =>
+      waitsForPromise(() => {
+        atom.config.set('linter-phpcs.tabWidth', 6);
+        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PEAR');
+        return lint(editor).then((messages) => {
+          const lastMessage = messages[messages.length - 1];
+          expect(lastMessage.excerpt).toBe('' +
+            '[Generic.Files.LineLength.TooLong]' +
+            ' Line exceeds 85 characters; ' +
+            'contains 128 characters');
+          expect(lastMessage.location.position).toEqual([[3, 122], [3, 123]]);
         });
       }),
     );


### PR DESCRIPTION
When the column returned by phpcs is greater than the line length, because tabs are counted as 4 spaces, `fixPHPCSColumn` will return the line length.

this prevents the `Invalid point encountered! See console for details.` error