### PR TITLE
Ignore the exit code of the version check

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,7 +24,7 @@ let showSource;
 let excludedSniffs;
 
 const determineExecVersion = async (execPath) => {
-  const versionString = await helpers.exec(execPath, ['--version']);
+  const versionString = await helpers.exec(execPath, ['--version'], { ignoreExitCode: true });
   const versionPattern = /^PHP_CodeSniffer version (\d+)\.(\d+)\.(\d+)/i;
   const version = versionString.match(versionPattern);
   const ver = {};


### PR DESCRIPTION
Apparently on some systems the version check can return a non-zero exit code for some bizarre reason. Ignore that case.

Re: https://github.com/AtomLinter/linter-phpcs/issues/254#issuecomment-299518094