### PR TITLE
Asyncify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,8 @@
   "devDependencies": {
     "eslint": "^3.12.0",
     "eslint-config-airbnb-base": "^11.0.0",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint-plugin-import": "^2.2.0",
+    "jasmine-fix": "^1.0.1"
   },
   "package-deps": [
     "linter:2.0.0"


### PR DESCRIPTION
Refactor the specs to utilize `async`/`await` after bringing in fixed versions of the Jasmine functions that support using them.