### PR TITLE
Utilize the semver library

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,10 +1,11 @@
 'use babel';
 
+import path from 'path';
+import semver from 'semver';
+import minimatch from 'minimatch';
+import * as helpers from 'atom-linter';
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
-import * as helpers from 'atom-linter';
-import path from 'path';
-import minimatch from 'minimatch';
 
 // Local variables
 const execPathVersions = new Map();
@@ -25,19 +26,11 @@ let excludedSniffs;
 
 const determineExecVersion = async (execPath) => {
   const versionString = await helpers.exec(execPath, ['--version'], { ignoreExitCode: true });
-  const versionPattern = /^PHP_CodeSniffer version (\d+)\.(\d+)\.(\d+)/i;
-  const version = versionString.match(versionPattern);
-  const ver = {};
-  if (version !== null) {
-    ver.major = Number.parseInt(version[1], 10);
-    ver.minor = Number.parseInt(version[2], 10);
-    ver.patch = Number.parseInt(version[3], 10);
-  } else {
-    ver.major = 0;
-    ver.minor = 0;
-    ver.patch = 0;
+  const versionPattern = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/i;
+  const match = versionString.match(versionPattern);
+  if (match !== null) {
+    execPathVersions.set(execPath, match[1]);
   }
-  execPathVersions.set(execPath, ver);
 };
 
 const getPHPCSVersion = async (execPath) => {
@@ -191,24 +184,19 @@ export default {
         const version = await getPHPCSVersion(executablePath);
 
         // -q (quiet) option is available since phpcs 2.6.2
-        if (version.major > 2
-          || (version.major === 2 && version.minor > 6)
-          || (version.major === 2 && version.minor === 6 && version.patch >= 2)
-        ) {
+        if (semver.gte(version, '2.6.2')) {
           parameters.push('-q');
         }
 
         // --encoding is available since 1.3.0 (RC1, but we ignore that for simplicity)
-        if (version.major > 1
-          || (version.major === 1 && version.minor >= 3)
-        ) {
+        if (semver.gte(version, '1.3.0')) {
           // actual file encoding is irrelevant, as PHPCS will always get UTF-8 as its input
           // see analysis here: https://github.com/AtomLinter/linter-phpcs/issues/235
           parameters.push('--encoding=UTF-8');
         }
 
         // Check if file should be ignored
-        if (version.major > 2) {
+        if (semver.gte(version, '3.0.0')) {
           // PHPCS v3 and up support this with STDIN files
           parameters.push(`--ignore=${ignorePatterns.join(',')}`);
         } else if (ignorePatterns.some(pattern => minimatch(filePath, pattern))) {
@@ -237,21 +225,17 @@ export default {
         }
 
         // Ignore any requested Sniffs
-        if (excludedSniffs.length > 0 && (
-          version.major > 2 ||
-          (version.major === 2 && version.minor > 6) ||
-          (version.major === 2 && version.minor === 6 && version.patch > 1)
-        )) {
+        if (excludedSniffs.length > 0 && semver.gte(version, '2.6.2')) {
           parameters.push(`--exclude=${excludedSniffs.join(',')}`);
         }
 
         // Determine the method of setting the file name
         let text;
-        if (version.major >= 3 || (version.major === 2 && version.minor >= 6)) {
+        if (semver.gte(version, '2.6.0')) {
           // PHPCS 2.6 and above support sending the filename in a flag
           parameters.push(`--stdin-path=${filePath}`);
           text = fileText;
-        } else if (version.major === 2 && version.minor < 6) {
+        } else if (semver.satisfies(version, '>=2.0.0 <2.6.0')) {
           // PHPCS 2.x.x before 2.6.0 supports putting the name in the start of the stream
           const eolChar = textEditor.getBuffer().lineEndingForRow(0);
           text = `phpcs_input_file: ${filePath}${eolChar}${fileText}`;
@@ -309,7 +293,7 @@ export default {
         }
 
         let messages;
-        if (version.major >= 2) {
+        if (semver.gte(version, '2.0.0')) {
           if (!data.files[filePath]) {
             return [];
           }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,8 @@
   "dependencies": {
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.5.0",
-    "minimatch": "^3.0.2"
+    "minimatch": "^3.0.2",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "eslint": "^3.12.0",


### PR DESCRIPTION
Instead of reinventing the wheel, just use the semver library to determine compatible versions of PHPCS.