### PR TITLE
Test all versions and fix tab handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,25 +8,66 @@ matrix:
   include:
     - os: linux
       language: php
+      php: 7.1
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="1.*"
+
+    - os: linux
+      language: php
+      php: 7.1
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="<2.6"
+
+    - os: linux
+      language: php
+      php: 7.1
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="2.6.1"
+
+    - os: linux
+      language: php
+      php: 7.1
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="2.*"
+
+    - os: linux
+      language: php
       php: 5.6
-      env: ATOM_CHANNEL=stable
-      install:
-        # Set the GitHub OAuth token for Composer
-        - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
-        - export PATH="$PATH:$HOME/.composer/vendor/bin"
-        # Install PHPCS
-        - composer global require "squizlabs/php_codesniffer=*"
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="*"
 
     - os: linux
       language: php
       php: 7.0
-      env: ATOM_CHANNEL=beta
-      install:
-        # Set the GitHub OAuth token for Composer
-        - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
-        - export PATH="$PATH:$HOME/.composer/vendor/bin"
-        # Install PHPCS
-        - composer global require "squizlabs/php_codesniffer=*"
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="*"
+
+    - os: linux
+      language: php
+      php: 7.1
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="*"
+
+    - os: linux
+      language: php
+      php: 7.1
+      env:
+        - ATOM_CHANNEL=beta
+        - PHPCS_VER="*"
+
+install:
+  # Set the GitHub OAuth token for Composer
+  - composer config -g github-oauth.github.com "$COMPOSER_OAUTH_TOKEN"
+  - export PATH="$PATH:$HOME/.composer/vendor/bin"
+  # Install PHPCS
+  - composer global require "squizlabs/php_codesniffer $PHPCS_VER"
 
 before_script:
   - phpcs --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 ### Project specific config ###
 environment:
   COMPOSER_OAUTH_TOKEN: "cc4a091c096e7d3cfe053c3f669fb840be60ab98"
+  PHPCS_VER: "*"
 
   matrix:
   - ATOM_CHANNEL: stable
@@ -26,7 +27,7 @@ install:
   - php composer config -g github-oauth.github.com "%COMPOSER_OAUTH_TOKEN%"
   - SET PATH=%APPDATA%\Composer\vendor\bin;%PATH%
   # Install PHPCS
-  - php composer global require "squizlabs/php_codesniffer=*"
+  - php composer global require "squizlabs/php_codesniffer %PHPCS_VER%"
   - phpcs --version
 
 ### Generic setup follows ###

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
     - chmod u+x build-package.sh
     - composer --version
     - composer config -g github-oauth.github.com cc4a091c096e7d3cfe053c3f669fb840be60ab98
-    - composer global require "squizlabs/php_codesniffer=*"
+    - composer global require "squizlabs/php_codesniffer $PHPCS_VER"
 
 machine:
   php:
@@ -17,3 +17,4 @@ machine:
   environment:
     COMPOSER_DISABLE_XDEBUG_WARN: 1
     COMPOSER_HOME: "/home/ubuntu/.composer"
+    PHPCS_VER: "*"

--- a/lib/main.js
+++ b/lib/main.js
@@ -189,11 +189,12 @@ export default {
         }
 
         // --encoding is available since 1.3.0 (RC1, but we ignore that for simplicity)
-        if (semver.gte(version, '1.3.0')) {
-          // actual file encoding is irrelevant, as PHPCS will always get UTF-8 as its input
-          // see analysis here: https://github.com/AtomLinter/linter-phpcs/issues/235
-          parameters.push('--encoding=UTF-8');
-        }
+        // Since PHPCS no longer publishes versions below v1.4.2 the conditional
+        // adding of this parameter has been removed.
+        parameters.push('--encoding=UTF-8');
+        // The actual file encoding is irrelevant, as PHPCS will always get
+        // UTF-8 as its input see analysis here:
+        // https://github.com/AtomLinter/linter-phpcs/issues/235
 
         // Check if file should be ignored
         if (semver.gte(version, '3.0.0')) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,10 +40,22 @@ const getPHPCSVersion = async (execPath) => {
   return execPathVersions.get(execPath);
 };
 
-const fixPHPCSColumn = (lineText, line, givenCol) => {
-  // Almost all PHPCS sniffs default to replacing tabs with 4 spaces
-  // This is horribly wrong, but that's how it works currently
-  const tabLength = tabWidth > 0 ? tabWidth : 4;
+const fixPHPCSColumn = (lineText, line, givenCol, currentStandards, version) => {
+  const forcedStandards = new Map();
+  forcedStandards.set('PSR2', 4);
+  forcedStandards.set('WordPress', 4);
+  let tabLength = tabWidth > 0 ? tabWidth : 1;
+  // NOTE: In v2 and up the tabWidth can't override standards
+  // Revisit this once https://github.com/squizlabs/PHP_CodeSniffer/issues/1457
+  // is released.
+  if (semver.satisfies(version, '>=2.0.0') || tabWidth < 1) {
+    forcedStandards.forEach((forcedTabs, standard) => {
+      if (currentStandards.includes(standard)) {
+        // These standards override the default tab-width
+        tabLength = forcedTabs;
+      }
+    });
+  }
   let column = givenCol;
   let screenCol = 0;
   for (let col = 0; col < lineText.length; col += 1) {
@@ -314,7 +326,7 @@ export default {
           const lineText = textEditor.getBuffer().lineForRow(line);
 
           if (lineText.includes('\t')) {
-            column = fixPHPCSColumn(lineText, line, column);
+            column = fixPHPCSColumn(lineText, line, column, standard, version);
           }
           column -= 1;
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "items": {
         "type": "string"
       },
-      "description": "Enter Glob patterns to ignore when running the linter.",
+      "description": "Enter Glob patterns to ignore when running PHPCS.",
       "order": 6
     },
     "displayErrorsOnly": {
@@ -68,8 +68,8 @@
     },
     "tabWidth": {
       "type": "integer",
-      "default": 0,
-      "description": "Set the number of spaces that tab characters represent to the linter. Will use 4 if set to 0 as most PHPCS sniffs have that as a hidden default.",
+      "default": 1,
+      "description": "Set the number of spaces that tab characters represent to PHPCS.",
       "order": 9
     },
     "showSource": {

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -1,10 +1,13 @@
 'use babel';
 
 import * as path from 'path';
+import { satisfies } from 'semver';
 // eslint-disable-next-line no-unused-vars, import/no-extraneous-dependencies
 import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
+import linterPhpcs from '../lib/main';
 
-const lint = require('../lib/main.js').provideLinter().lint;
+const lint = linterPhpcs.provideLinter().lint;
+let phpcsVer;
 
 const goodPath = path.join(__dirname, 'files', 'good.php');
 const badPath = path.join(__dirname, 'files', 'bad.php');
@@ -13,11 +16,38 @@ const emptyPath = path.join(__dirname, 'files', 'empty.php');
 const longCP1251Path = path.join(__dirname, 'files', 'long.cp1251.php');
 const shortCP1251Path = path.join(__dirname, 'files', 'short.cp1251.php');
 
+function throwingLint(editor) {
+  return new Promise(async (resolve, reject) => {
+    try {
+      await lint(editor);
+    } catch (e) {
+      resolve(true);
+    }
+    reject(false);
+  });
+}
+
 describe('The phpcs provider for Linter', () => {
   beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
     await atom.packages.activatePackage('linter-phpcs');
     await atom.packages.activatePackage('language-php');
+    // Set the expected PHPCS version
+    const fakeVer = {
+      '1.*': '1.0.0',
+      '<2.6': '2.5.1',
+      '2.6.1': '2.6.1',
+      '2.*': '2.9.0',
+      '*': '3.0.0',
+    };
+    let phpcsSpecVer;
+    if (Object.prototype.hasOwnProperty.call(process.env, 'PHPCS_VER')) {
+      // This will be set in the CI environments
+      phpcsSpecVer = process.env.PHPCS_VER;
+    } else {
+      phpcsSpecVer = '*';
+    }
+    phpcsVer = fakeVer[phpcsSpecVer];
   });
 
   it('should be in the packages list', () =>
@@ -62,9 +92,14 @@ describe('The phpcs provider for Linter', () => {
     });
 
     it('reports line length warning', async () => {
-      const messages = await lint(editor);
-      expect(messages.length).toBe(1);
-      expect(messages[0].excerpt).toMatch(/Line exceeds/);
+      if (satisfies(phpcsVer, '<2')) {
+        // PHPCS v1 has a bug with cp1251 encoded files and gives invalid points
+        expect(await throwingLint(editor)).toBe(true);
+      } else {
+        const messages = await lint(editor);
+        expect(messages.length).toBe(1);
+        expect(messages[0].excerpt).toMatch(/Line exceeds/);
+      }
     });
   });
 
@@ -90,25 +125,69 @@ describe('The phpcs provider for Linter', () => {
   describe('checks tabs.php and', () => {
     let editor = null;
     beforeEach(async () => {
-      atom.config.set('linter-phpcs.tabWidth', 4);
+      // NOTE: The default PSR2 standard forces tabWidth to 4
+      atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PEAR');
       editor = await atom.workspace.open(tabsPath);
     });
 
-    it('finds at least two messages', async () => {
+    it('works with a the default tab-width', async () => {
       const messages = await lint(editor);
-      expect(messages.length).toBeGreaterThan(1);
-    });
-
-    it('verifies the second message', async () => {
-      const messages = await lint(editor);
-      expect(messages[1].severity).toBe('error');
-      expect(messages[1].description).not.toBeDefined();
-      expect(messages[1].excerpt).toBe('' +
+      expect(messages.length).toBe(4);
+      const tabMessage = messages[3];
+      expect(tabMessage.severity).toBe('error');
+      expect(tabMessage.description).not.toBeDefined();
+      expect(tabMessage.excerpt).toBe('' +
         '[Generic.PHP.LowerCaseConstant.Found]' +
         ' TRUE, FALSE and NULL must be lowercase; ' +
         'expected "true" but found "TRUE"');
-      expect(messages[1].location.file).toBe(tabsPath);
-      expect(messages[1].location.position).toEqual([[2, 6], [2, 10]]);
+      expect(tabMessage.location.file).toBe(tabsPath);
+      expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
+    });
+
+    it('works with a non-default tab-width', async () => {
+      atom.config.set('linter-phpcs.tabWidth', 12);
+      const messages = await lint(editor);
+      let tabMessage;
+      if (satisfies(phpcsVer, '<2')) {
+        expect(messages.length).toBe(2);
+        tabMessage = messages[1];
+      } else {
+        expect(messages.length).toBe(3);
+        tabMessage = messages[2];
+      }
+      expect(tabMessage.severity).toBe('error');
+      expect(tabMessage.description).not.toBeDefined();
+      expect(tabMessage.excerpt).toBe('' +
+        '[Generic.PHP.LowerCaseConstant.Found]' +
+        ' TRUE, FALSE and NULL must be lowercase; ' +
+        'expected "true" but found "TRUE"');
+      expect(tabMessage.location.file).toBe(tabsPath);
+      expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
+    });
+
+    it('handles forced standards properly', async () => {
+      atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
+      atom.config.set('linter-phpcs.tabWidth', 12);
+      const messages = await lint(editor);
+      let tabMessage;
+      if (satisfies(phpcsVer, '<2')) {
+        expect(messages.length).toBe(1);
+        tabMessage = messages[0];
+      } else {
+        expect(messages.length).toBe(2);
+        tabMessage = messages[1];
+      }
+      expect(tabMessage.severity).toBe('error');
+      expect(tabMessage.description).not.toBeDefined();
+      expect(tabMessage.excerpt).toBe('' +
+        '[Generic.PHP.LowerCaseConstant.Found]' +
+        ' TRUE, FALSE and NULL must be lowercase; ' +
+        'expected "true" but found "TRUE"');
+      expect(tabMessage.location.file).toBe(tabsPath);
+      // Note that for broken versions (v2.0.0 and up) the tab width setting
+      // is ignored. We can't test the raw value returned here, but we can check
+      // that it is being handled correctly.
+      expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
     });
   });
 
@@ -125,10 +204,16 @@ describe('The phpcs provider for Linter', () => {
   });
 
   it('allows specifying sniffs to ignore', async () => {
-    atom.config.set('linter-phpcs.excludedSniffs', ['Generic.PHP.LowerCaseConstant']);
-    const editor = await atom.workspace.open(badPath);
-    const messages = await lint(editor);
-    // Note that we have earlier checked that it should be 1 normally
-    expect(messages.length).toBe(0);
+    if (satisfies(phpcsVer, '<2.6.2')) {
+      // Versions below v2.6.2 don't support excluding sniffs
+      expect(true).toBe(true);
+    } else {
+      const editor = await atom.workspace.open(badPath);
+      let messages = await lint(editor);
+      expect(messages.length).toBe(1);
+      atom.config.set('linter-phpcs.excludedSniffs', ['Generic.PHP.LowerCaseConstant']);
+      messages = await lint(editor);
+      expect(messages.length).toBe(0);
+    }
   });
 });


### PR DESCRIPTION
The specs were previously only testing the latest version, even though several paths through the code only activate for specific versions of PHPCS. Update the CI and specs to test all versions with a special case handling them. Includes:
- `1.*` (currently 1.5.6)
- `<2.6` (currently 2.5.1)
- `2.6.1`
- `2.*` (currently 2.9.0)
- `*` (currently 3.0.0)

As the updated specs would have caused the current code to fail due to a bug in how it handles tabs, this PR also includes a patch to `fixPHPCSColumn` to properly handle tabs in all versions, including an override for standards that specify it directly which causes most PHPCS versions to ignore the `--tab-width` argument.

Also removes conditional adding of --encoding as versions without it are no longer published.