### PR TITLE
Improve startup time

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,11 +1,27 @@
 'use babel';
 
-import path from 'path';
-import semver from 'semver';
-import minimatch from 'minimatch';
-import * as helpers from 'atom-linter';
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
+
+let semver;
+let minimatch;
+let helpers;
+let path;
+
+function loadDeps() {
+  if (!semver) {
+    semver = require('semver');
+  }
+  if (!minimatch) {
+    minimatch = require('minimatch');
+  }
+  if (!helpers) {
+    helpers = require('atom-linter');
+  }
+  if (!path) {
+    path = require('path');
+  }
+}
 
 // Local variables
 const execPathVersions = new Map();
@@ -70,7 +86,17 @@ const scopeAvailable = (scope, available) => {
 
 export default {
   activate() {
-    require('atom-package-deps').install('linter-phpcs');
+    this.idleCallbacks = new Set();
+    let depsCallbackID;
+    const installLinterPhpcsDeps = () => {
+      this.idleCallbacks.delete(depsCallbackID);
+      if (!atom.inSpecMode()) {
+        require('atom-package-deps').install('linter-phpcs');
+      }
+      loadDeps();
+    };
+    depsCallbackID = window.requestIdleCallback(installLinterPhpcsDeps);
+    this.idleCallbacks.add(depsCallbackID);
 
     this.subscriptions = new CompositeDisposable();
 
@@ -123,6 +149,8 @@ export default {
   },
 
   deactivate() {
+    this.idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+    this.idleCallbacks.clear();
     this.subscriptions.dispose();
   },
 
@@ -135,12 +163,14 @@ export default {
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
         const fileText = textEditor.getText();
-        const fileDir = path.dirname(filePath);
 
         if (fileText === '') {
           // Empty file, empty results
           return [];
         }
+
+        loadDeps();
+        const fileDir = path.dirname(filePath);
 
         let executable = this.executablePath;
         const parameters = ['--report=json'];

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,19 +11,6 @@ import { CompositeDisposable } from 'atom';
 const execPathVersions = new Map();
 const grammarScopes = ['source.php'];
 
-// Settings
-let executablePath;
-let autoExecutableSearch;
-let disableWhenNoConfigFile;
-let codeStandardOrConfigFile;
-let autoConfigSearch;
-let ignorePatterns;
-let errorsOnly;
-let warningSeverity;
-let tabWidth;
-let showSource;
-let excludedSniffs;
-
 const determineExecVersion = async (execPath) => {
   const versionString = await helpers.exec(execPath, ['--version'], { ignoreExitCode: true });
   const versionPattern = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/i;
@@ -40,7 +27,7 @@ const getPHPCSVersion = async (execPath) => {
   return execPathVersions.get(execPath);
 };
 
-const fixPHPCSColumn = (lineText, line, givenCol, currentStandards, version) => {
+const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version) => {
   const forcedStandards = new Map();
   forcedStandards.set('PSR2', 4);
   forcedStandards.set('WordPress', 4);
@@ -94,65 +81,41 @@ export default {
 
     this.subscriptions.add(
       atom.config.observe('linter-phpcs.executablePath', (value) => {
-        executablePath = value;
+        this.executablePath = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.autoExecutableSearch', (value) => {
-        autoExecutableSearch = value;
+        this.autoExecutableSearch = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.disableWhenNoConfigFile', (value) => {
-        disableWhenNoConfigFile = value;
+        this.disableWhenNoConfigFile = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.codeStandardOrConfigFile', (value) => {
-        codeStandardOrConfigFile = value;
+        this.codeStandardOrConfigFile = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.autoConfigSearch', (value) => {
-        autoConfigSearch = value;
+        this.autoConfigSearch = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.ignorePatterns', (value) => {
-        ignorePatterns = value;
+        this.ignorePatterns = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.displayErrorsOnly', (value) => {
-        errorsOnly = value;
+        this.errorsOnly = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.warningSeverity', (value) => {
-        warningSeverity = value;
+        this.warningSeverity = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.tabWidth', (value) => {
-        tabWidth = value;
+        this.tabWidth = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.showSource', (value) => {
-        showSource = value;
+        this.showSource = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.excludedSniffs', (value) => {
-        excludedSniffs = value;
+        this.excludedSniffs = value;
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.otherLanguages.useCSSTools', (value) => {
         scopeAvailable('source.css', value);
       }),
-    );
-    this.subscriptions.add(
       atom.config.observe('linter-phpcs.otherLanguages.useJSTools', (value) => {
         scopeAvailable('source.js', value);
       }),
@@ -179,21 +142,22 @@ export default {
           return [];
         }
 
+        let executable = this.executablePath;
         const parameters = ['--report=json'];
 
         // Check if a local PHPCS executable is available
-        if (autoExecutableSearch) {
-          const executable = await helpers.findCachedAsync(
+        if (this.autoExecutableSearch) {
+          const projExecutable = await helpers.findCachedAsync(
             fileDir, ['vendor/bin/phpcs.bat', 'vendor/bin/phpcs'],
           );
 
-          if (executable !== null) {
-            executablePath = executable;
+          if (projExecutable !== null) {
+            executable = projExecutable;
           }
         }
 
         // Get the version of the chosen PHPCS
-        const version = await getPHPCSVersion(executablePath);
+        const version = await getPHPCSVersion(executable);
 
         // -q (quiet) option is available since phpcs 2.6.2
         if (semver.gte(version, '2.6.2')) {
@@ -211,8 +175,8 @@ export default {
         // Check if file should be ignored
         if (semver.gte(version, '3.0.0')) {
           // PHPCS v3 and up support this with STDIN files
-          parameters.push(`--ignore=${ignorePatterns.join(',')}`);
-        } else if (ignorePatterns.some(pattern => minimatch(filePath, pattern))) {
+          parameters.push(`--ignore=${this.ignorePatterns.join(',')}`);
+        } else if (this.ignorePatterns.some(pattern => minimatch(filePath, pattern))) {
           // We must determine this ourself for lower versions
           return [];
         }
@@ -221,25 +185,26 @@ export default {
         const confFile = await helpers.findAsync(fileDir,
           ['phpcs.xml', 'phpcs.xml.dist', 'phpcs.ruleset.xml', 'ruleset.xml'],
         );
-        if (disableWhenNoConfigFile && !confFile) {
+        if (this.disableWhenNoConfigFile && !confFile) {
           return [];
         }
 
-        const standard = autoConfigSearch && confFile ? confFile : codeStandardOrConfigFile;
+        const standard = this.autoConfigSearch && confFile ?
+          confFile : this.codeStandardOrConfigFile;
         if (standard) {
           parameters.push(`--standard=${standard}`);
         }
-        parameters.push(`--warning-severity=${errorsOnly ? 0 : warningSeverity}`);
-        if (tabWidth > 1) {
-          parameters.push(`--tab-width=${tabWidth}`);
+        parameters.push(`--warning-severity=${this.errorsOnly ? 0 : this.warningSeverity}`);
+        if (this.tabWidth > 1) {
+          parameters.push(`--tab-width=${this.tabWidth}`);
         }
-        if (showSource) {
+        if (this.showSource) {
           parameters.push('-s');
         }
 
         // Ignore any requested Sniffs
-        if (excludedSniffs.length > 0 && semver.gte(version, '2.6.2')) {
-          parameters.push(`--exclude=${excludedSniffs.join(',')}`);
+        if (this.excludedSniffs.length > 0 && semver.gte(version, '2.6.2')) {
+          parameters.push(`--exclude=${this.excludedSniffs.join(',')}`);
         }
 
         // Determine the method of setting the file name
@@ -278,7 +243,7 @@ export default {
           execOptions.cwd = path.dirname(confFile);
         }
 
-        const result = await helpers.exec(executablePath, parameters, execOptions);
+        const result = await helpers.exec(executable, parameters, execOptions);
 
         if (result === null) {
           // Our specific spawn was terminated by a newer call, tell Linter not
@@ -326,7 +291,7 @@ export default {
           const lineText = textEditor.getBuffer().lineForRow(line);
 
           if (lineText.includes('\t')) {
-            column = fixPHPCSColumn(lineText, line, column, standard, version);
+            column = fixPHPCSColumn(lineText, column, this.tabWidth, standard, version);
           }
           column -= 1;
 
@@ -367,7 +332,7 @@ export default {
             },
           };
 
-          if (showSource) {
+          if (this.showSource) {
             msg.excerpt = `[${message.source || 'Unknown'}] ${message.message}`;
           } else {
             msg.excerpt = message.message;

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
       "atom": true
     },
     "env": {
-      "node": true
+      "node": true,
+      "browser": true
     }
   }
 }


### PR DESCRIPTION
Move checking for Atom package dependencies to an idle callback as it doesn't need to be done immediately during activation. Also moves loading of dependencies to on demand, with an opportunistic load in the idle callback.