### PR TITLE
Add more WordPress standards to override list

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -47,6 +47,10 @@ const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version)
   const forcedStandards = new Map();
   forcedStandards.set('PSR2', 4);
   forcedStandards.set('WordPress', 4);
+  forcedStandards.set('WordPress-Core', 4);
+  forcedStandards.set('WordPress-Docs', 4);
+  forcedStandards.set('WordPress-Extra', 4);
+  forcedStandards.set('WordPress-VIP', 4);
   let tabLength = tabWidth > 0 ? tabWidth : 1;
   // NOTE: In v2 and up the tabWidth can't override standards
   // Revisit this once https://github.com/squizlabs/PHP_CodeSniffer/issues/1457


### PR DESCRIPTION
Turns out there are some additional WordPress standards that should be included in the default exclusion list due to their popularity.

Fixes https://github.com/AtomLinter/linter-phpcs/issues/252#issuecomment-301041825.