### PR TITLE
Support hack language if user has nuclide-hack-language package installed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -27,6 +27,12 @@ function loadDeps() {
 const execPathVersions = new Map();
 const grammarScopes = ['source.php'];
 
+// If user has the nuclide (https://nuclide.io/) package installed,
+// 'text.html.hack' will be the correct grammar for *.php files.
+if (atom.packages.isPackageActive('nuclide-language-hack')) {
+  grammarScopes.push('text.html.hack');
+}
+
 const determineExecVersion = async (execPath) => {
   const versionString = await helpers.exec(execPath, ['--version'], { ignoreExitCode: true });
   const versionPattern = /^PHP_CodeSniffer version (\d+\.\d+\.\d+)/i;


### PR DESCRIPTION
If a user has the [nuclide](https://nuclide.io) package installed, files with the `.php` extension will no longer use the `source.php` grammar but will instead use the `text.html.hack` grammar, even if manually setting the syntax to `php`. This change ensures the correct grammar will be used _if_ the package defining the grammar is active.