### PR TITLE
Add correct grammar based off of file extension

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,7 @@ const getScopeNamesForFileExtension = (extension) => {
     const grammar = atom.grammars.getGrammars()[i];
     if (grammar.fileTypes.includes(extension)) {
       fileExtensionGrammars.push(grammar.scopeName);
+      continue;
     }
   }
   return fileExtensionGrammars;

--- a/lib/main.js
+++ b/lib/main.js
@@ -140,7 +140,7 @@ export default {
         for (let i = 0; i < value.length; i += 1) {
           const scopes = getScopeNamesForFileExtension(value[i]);
           for (let n = 0; n < scopes.length; n += 1) {
-            scopeAvailable(scopes[n]);
+            scopeAvailable(scopes[n], true);
           }
         }
         this.extensions = value;

--- a/lib/main.js
+++ b/lib/main.js
@@ -43,6 +43,17 @@ const getPHPCSVersion = async (execPath) => {
   return execPathVersions.get(execPath);
 };
 
+const getScopeNamesForFileExtension = (extension) {
+  const fileExtensionGrammars - [];
+  for (let i = 0; i < atom.grammars.getGrammars().length; i += 1) {
+    let grammar = atom.grammars.getGrammars()[i];
+    if (grammar.fileTypes.includes(extension)) {
+      fileExtensionGrammars.push(grammar.scopeName);
+    }
+  }
+  return fileExtensionGrammars;
+}
+
 const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version) => {
   const forcedStandards = new Map();
   forcedStandards.set('PSR2', 4);
@@ -88,24 +99,6 @@ const scopeAvailable = (scope, available) => {
   }
 };
 
-const grammars = atom.grammars.getGrammars().filter((grammar) => grammar !== atom.grammars.nullGrammar);
-let grammarFileTypes;
-
-for (let i = 0; i < grammars.length; i += 1) {
-  const grammar = grammars[i].scopeName;
-  const fileTypes = grammars[i].fileTypes;
-  let object = {};
-  for (let n = 0; n < fileTypes.length; n += 1) {
-    object[fileTypes[n]] = grammar;
-  }
-  grammarFileTypes = Object.assign({}, grammarFileTypes, object);
-}
-
-console.log(grammarFileTypes);
-const isGrammarValid = (extension) => {
-  return grammarFileTypes.hasOwnProperty(extension);
-};
-
 export default {
   activate() {
     this.idleCallbacks = new Set();
@@ -145,28 +138,9 @@ export default {
       }),
       atom.config.observe('linter-phpcs.extensions', (value) => {
         for (let i = 0; i < value.length; i += 1) {
-          if (value[i].indexOf('/') > -1) {
-            const entry = value[i].split('/');
-            const ext = entry[0];
-            const type = entry[1];
-            let grammar;
-            if (isGrammarValid(ext)) {
-              grammar = grammarFileTypes[ext];
-              scopeAvailable(grammar);
-            } else if (isGrammarValid(type)) {
-              grammar = grammarFileTypes[type];
-              scopeAvailable(grammar);
-            } else {
-              let message = ext + '/' + type + ' is not supported.';
-              atom.notifications.addError(message);
-            }
-          } else {
-            if (isGrammarValid(value[i])) {
-              scopeAvailable(value[i]);
-            } else {
-              let message = value[i] + ' is not supported.';
-              atom.notifications.addError(message);
-            }
+          let scopes = getScopeNameForFileExtension(value[i]);
+          for (let n = 0; n < scopes.length; n ++1) {
+            scopeAvailable(scopes[n]);
           }
         }
         this.extensions = value;

--- a/lib/main.js
+++ b/lib/main.js
@@ -43,16 +43,16 @@ const getPHPCSVersion = async (execPath) => {
   return execPathVersions.get(execPath);
 };
 
-const getScopeNamesForFileExtension = (extension) {
-  const fileExtensionGrammars - [];
+const getScopeNamesForFileExtension = (extension) => {
+  const fileExtensionGrammars = [];
   for (let i = 0; i < atom.grammars.getGrammars().length; i += 1) {
-    let grammar = atom.grammars.getGrammars()[i];
+    const grammar = atom.grammars.getGrammars()[i];
     if (grammar.fileTypes.includes(extension)) {
       fileExtensionGrammars.push(grammar.scopeName);
     }
   }
   return fileExtensionGrammars;
-}
+};
 
 const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version) => {
   const forcedStandards = new Map();
@@ -138,8 +138,8 @@ export default {
       }),
       atom.config.observe('linter-phpcs.extensions', (value) => {
         for (let i = 0; i < value.length; i += 1) {
-          let scopes = getScopeNameForFileExtension(value[i]);
-          for (let n = 0; n < scopes.length; n ++1) {
+          const scopes = getScopeNamesForFileExtension(value[i]);
+          for (let n = 0; n < scopes.length; n += 1) {
             scopeAvailable(scopes[n]);
           }
         }

--- a/lib/main.js
+++ b/lib/main.js
@@ -88,6 +88,24 @@ const scopeAvailable = (scope, available) => {
   }
 };
 
+const grammars = atom.grammars.getGrammars().filter((grammar) => grammar !== atom.grammars.nullGrammar);
+let grammarFileTypes;
+
+for (let i = 0; i < grammars.length; i += 1) {
+  const grammar = grammars[i].scopeName;
+  const fileTypes = grammars[i].fileTypes;
+  let object = {};
+  for (let n = 0; n < fileTypes.length; n += 1) {
+    object[fileTypes[n]] = grammar;
+  }
+  grammarFileTypes = Object.assign({}, grammarFileTypes, object);
+}
+
+console.log(grammarFileTypes);
+const isGrammarValid = (extension) => {
+  return grammarFileTypes.hasOwnProperty(extension);
+};
+
 export default {
   activate() {
     this.idleCallbacks = new Set();
@@ -124,6 +142,34 @@ export default {
       }),
       atom.config.observe('linter-phpcs.autoConfigSearch', (value) => {
         this.autoConfigSearch = value;
+      }),
+      atom.config.observe('linter-phpcs.extensions', (value) => {
+        for (let i = 0; i < value.length; i += 1) {
+          if (value[i].indexOf('/') > -1) {
+            const entry = value[i].split('/');
+            const ext = entry[0];
+            const type = entry[1];
+            let grammar;
+            if (isGrammarValid(ext)) {
+              grammar = grammarFileTypes[ext];
+              scopeAvailable(grammar);
+            } else if (isGrammarValid(type)) {
+              grammar = grammarFileTypes[type];
+              scopeAvailable(grammar);
+            } else {
+              let message = ext + '/' + type + ' is not supported.';
+              atom.notifications.addError(message);
+            }
+          } else {
+            if (isGrammarValid(value[i])) {
+              scopeAvailable(value[i]);
+            } else {
+              let message = value[i] + ' is not supported.';
+              atom.notifications.addError(message);
+            }
+          }
+        }
+        this.extensions = value;
       }),
       atom.config.observe('linter-phpcs.ignorePatterns', (value) => {
         this.ignorePatterns = value;
@@ -214,6 +260,11 @@ export default {
           // We must determine this ourself for lower versions
           return [];
         }
+
+        // --extensions is available since 1.30.
+        // Since PHPCS no longer publishes versions below v1.4.2 it's not
+        // necessary to wrap this statement in a conditional.
+        parameters.push(`--extensions=${this.extensions.join(',')}`);
 
         // Check if a config file exists and handle it
         const confFile = await helpers.findAsync(fileDir,

--- a/lib/main.js
+++ b/lib/main.js
@@ -235,11 +235,6 @@ export default {
           return [];
         }
 
-        // --extensions is available since 1.30.
-        // Since PHPCS no longer publishes versions below v1.4.2 it's not
-        // necessary to wrap this statement in a conditional.
-        parameters.push(`--extensions=${this.extensions.join(',')}`);
-
         // Check if a config file exists and handle it
         const confFile = await helpers.findAsync(fileDir,
           ['phpcs.xml', 'phpcs.xml.dist', 'phpcs.ruleset.xml', 'ruleset.xml'],

--- a/package.json
+++ b/package.json
@@ -42,6 +42,18 @@
       "description": "Automatically search for any `phpcs.xml`, `phpcs.xml.dist`, `phpcs.ruleset.xml` or `ruleset.xml` file to use as configuration. Overrides custom standards defined above.",
       "order": 5
     },
+    "extensions": {
+      "type": "array",
+      "default": [
+        "php",
+        "inc"
+      ],
+      "items": {
+        "type": "string"
+      },
+      "description": "A comma separated list of file extensions to check. The type of the file can be specified using: ext/type e.g., module/php,es/js",
+      "order": 6
+    },
     "ignorePatterns": {
       "type": "array",
       "default": [
@@ -52,31 +64,31 @@
         "type": "string"
       },
       "description": "Enter Glob patterns to ignore when running PHPCS.",
-      "order": 6
+      "order": 7
     },
     "displayErrorsOnly": {
       "type": "boolean",
       "default": false,
       "description": "Ignore warnings and display errors only.",
-      "order": 7
+      "order": 8
     },
     "warningSeverity": {
       "type": "integer",
       "default": 1,
       "description": "Set the warning severity level. Available when \"Display Errors Only\" is not checked.",
-      "order": 8
+      "order": 9
     },
     "tabWidth": {
       "type": "integer",
       "default": 1,
       "description": "Set the number of spaces that tab characters represent to PHPCS.",
-      "order": 9
+      "order": 10
     },
     "showSource": {
       "type": "boolean",
       "default": true,
       "description": "Show source in message.",
-      "order": 10
+      "order": 11
     },
     "excludedSniffs": {
       "type": "array",
@@ -85,13 +97,13 @@
         "type": "string"
       },
       "description": "Command separated list of Sniffs to ignore. Ignored below PHPCS v2.6.2.",
-      "order": 11
+      "order": 12
     },
     "otherLanguages": {
       "type": "object",
       "collapsed": true,
       "description": "If properly configured, PHPCS can run external tools to lint languages other than PHP. Only enable the below options if you have set this up.",
-      "order": 12,
+      "order": 13,
       "properties": {
         "useCSSTools": {
           "title": "Enable CSS Tools",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "items": {
         "type": "string"
       },
-      "description": "A comma separated list of file extensions to check. The type of the file can be specified using: ext/type e.g., module/php,es/js",
+      "description": "A comma separated list of file extensions to check.",
       "order": 6
     },
     "ignorePatterns": {


### PR DESCRIPTION
When a user specifies a file extension, this change will add the correct grammar scope for that file type to the `grammarScopes` array.

For example: if the `php` file extension is using `type.html.hack` instead of `source.php`, then `type.html.hack` will be added to the grammar scope.