### PR TITLE
Move to the Trusty image on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,8 @@ git:
 
 sudo: false
 
+dist: "trusty"
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
The Atom Beta builds essentially require Trusty to get a new enough `glibc` library.