### PR TITLE
Handle tabWidth setting properly in PHPCS v3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,13 @@ matrix:
 
     - os: linux
       language: php
+      php: 7.1
+      env:
+        - ATOM_CHANNEL=stable
+        - PHPCS_VER="3.0.0"
+
+    - os: linux
+      language: php
       php: 5.6
       env:
         - ATOM_CHANNEL=stable

--- a/lib/main.js
+++ b/lib/main.js
@@ -55,10 +55,8 @@ const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version)
   forcedStandards.set('WordPress-Extra', 4);
   forcedStandards.set('WordPress-VIP', 4);
   let tabLength = tabWidth > 0 ? tabWidth : 1;
-  // NOTE: In v2 and up the tabWidth can't override standards
-  // Revisit this once https://github.com/squizlabs/PHP_CodeSniffer/issues/1457
-  // is released.
-  if (semver.satisfies(version, '>=2.0.0') || tabWidth < 1) {
+  // NOTE: Between v2.x.y and v3.0.0 the tabWidth can't override standards
+  if (semver.satisfies(version, '>=2.0.0 <3.0.1') || tabWidth < 1) {
     forcedStandards.forEach((forcedTabs, standard) => {
       if (currentStandards.includes(standard)) {
         // These standards override the default tab-width


### PR DESCRIPTION
PHPCS v3.0.1 finally fixed the bug where standards could override the explicit `tabWidth` setting entered in via the command line, allowing us to stop overriding standards that used to break everything.