### PR TITLE
Fix handling of forced standards with default tabWidth

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -29,6 +29,7 @@ const grammarScopes = [
   'source.php',
   'text.html.php', // Workaround for Nuclide bug, see #272
 ];
+let tabWidthDefault;
 
 const determineExecVersion = async (execPath) => {
   const versionString = await helpers.exec(execPath, ['--version'], { ignoreExitCode: true });
@@ -47,16 +48,16 @@ const getPHPCSVersion = async (execPath) => {
 };
 
 const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version) => {
-  const forcedStandards = new Map();
-  forcedStandards.set('PSR2', 4);
-  forcedStandards.set('WordPress', 4);
-  forcedStandards.set('WordPress-Core', 4);
-  forcedStandards.set('WordPress-Docs', 4);
-  forcedStandards.set('WordPress-Extra', 4);
-  forcedStandards.set('WordPress-VIP', 4);
-  let tabLength = tabWidth > 0 ? tabWidth : 1;
+  let tabLength = tabWidth;
   // NOTE: Between v2.x.y and v3.0.0 the tabWidth can't override standards
-  if (semver.satisfies(version, '>=2.0.0 <3.0.1') || tabWidth < 1) {
+  if (semver.satisfies(version, '>=2.0.0 <3.0.1') || tabWidth === tabWidthDefault) {
+    const forcedStandards = new Map();
+    forcedStandards.set('PSR2', 4);
+    forcedStandards.set('WordPress', 4);
+    forcedStandards.set('WordPress-Core', 4);
+    forcedStandards.set('WordPress-Docs', 4);
+    forcedStandards.set('WordPress-Extra', 4);
+    forcedStandards.set('WordPress-VIP', 4);
     forcedStandards.forEach((forcedTabs, standard) => {
       if (currentStandards.includes(standard)) {
         // These standards override the default tab-width
@@ -151,6 +152,8 @@ export default {
         scopeAvailable('source.js', value);
       }),
     );
+
+    tabWidthDefault = atom.config.getSchema('linter-phpcs.tabWidth').default;
   },
 
   deactivate() {
@@ -230,7 +233,7 @@ export default {
           parameters.push(`--standard=${standard}`);
         }
         parameters.push(`--warning-severity=${this.errorsOnly ? 0 : this.warningSeverity}`);
-        if (this.tabWidth > 1) {
+        if (this.tabWidth !== tabWidthDefault) {
           parameters.push(`--tab-width=${this.tabWidth}`);
         }
         if (this.showSource) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -48,9 +48,10 @@ const getPHPCSVersion = async (execPath) => {
 };
 
 const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version) => {
+  const defaultTabs = tabWidth === tabWidthDefault;
   let tabLength = tabWidth;
   // NOTE: Between v2.x.y and v3.0.0 the tabWidth can't override standards
-  if (semver.satisfies(version, '>=2.0.0 <3.0.1') || tabWidth === tabWidthDefault) {
+  if (semver.satisfies(version, '>=2.0.0 <3.0.1') || defaultTabs) {
     const forcedStandards = new Map();
     forcedStandards.set('PSR2', 4);
     forcedStandards.set('WordPress', 4);
@@ -64,6 +65,10 @@ const fixPHPCSColumn = (lineText, givenCol, tabWidth, currentStandards, version)
         tabLength = forcedTabs;
       }
     });
+  }
+  if (semver.satisfies(version, '<2.0.0') && defaultTabs) {
+    // PHPCS lower than v2 ignores standards forced tabLength
+    tabLength = 1;
   }
   let column = givenCol;
   let screenCol = 0;

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -165,29 +165,40 @@ describe('The phpcs provider for Linter', () => {
       expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
     });
 
-    it('handles forced standards properly', async () => {
-      atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
-      atom.config.set('linter-phpcs.tabWidth', 12);
-      const messages = await lint(editor);
-      let tabMessage;
-      if (satisfies(phpcsVer, '<2')) {
-        expect(messages.length).toBe(1);
-        tabMessage = messages[0];
-      } else {
-        expect(messages.length).toBe(2);
-        tabMessage = messages[1];
-      }
-      expect(tabMessage.severity).toBe('error');
-      expect(tabMessage.description).not.toBeDefined();
-      expect(tabMessage.excerpt).toBe('' +
+    describe('handles forced standards properly', () => {
+      async function checkForcedStandard() {
+        const messages = await lint(editor);
+        let tabMessage;
+        if (satisfies(phpcsVer, '<2')) {
+          expect(messages.length).toBe(1);
+          tabMessage = messages[0];
+        } else {
+          expect(messages.length).toBe(2);
+          tabMessage = messages[1];
+        }
+        expect(tabMessage.severity).toBe('error');
+        expect(tabMessage.description).not.toBeDefined();
+        expect(tabMessage.excerpt).toBe('' +
         '[Generic.PHP.LowerCaseConstant.Found]' +
         ' TRUE, FALSE and NULL must be lowercase; ' +
         'expected "true" but found "TRUE"');
-      expect(tabMessage.location.file).toBe(tabsPath);
-      // Note that for broken versions (v2.0.0 and up) the tab width setting
-      // is ignored. We can't test the raw value returned here, but we can check
-      // that it is being handled correctly.
-      expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
+        expect(tabMessage.location.file).toBe(tabsPath);
+        // Note that for broken versions (v2.0.0 through v3.0.0) the tab width
+        // setting is ignored. We can't test the raw value returned here, but we
+        // can check that it is being handled correctly.
+        expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
+      }
+
+      it('works with the default tab width', async () => {
+        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
+        await checkForcedStandard();
+      });
+
+      it('works with a forced tab width', async () => {
+        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
+        atom.config.set('linter-phpcs.tabWidth', 12);
+        await checkForcedStandard();
+      });
     });
   });
 

--- a/spec/linter-phpcs-spec.js
+++ b/spec/linter-phpcs-spec.js
@@ -124,6 +124,21 @@ describe('The phpcs provider for Linter', () => {
 
   describe('checks tabs.php and', () => {
     let editor = null;
+
+    function checkTabMessage(tabMessage) {
+      expect(tabMessage.severity).toBe('error');
+      expect(tabMessage.description).not.toBeDefined();
+      expect(tabMessage.excerpt).toBe('' +
+      '[Generic.PHP.LowerCaseConstant.Found]' +
+      ' TRUE, FALSE and NULL must be lowercase; ' +
+      'expected "true" but found "TRUE"');
+      expect(tabMessage.location.file).toBe(tabsPath);
+      // Note that for broken versions (v2.0.0 through v3.0.0) the tab width
+      // setting is ignored. We can't test the raw value returned here, but we
+      // can check that it is being handled correctly.
+      expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
+    }
+
     beforeEach(async () => {
       // NOTE: The default PSR2 standard forces tabWidth to 4
       atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PEAR');
@@ -134,14 +149,7 @@ describe('The phpcs provider for Linter', () => {
       const messages = await lint(editor);
       expect(messages.length).toBe(4);
       const tabMessage = messages[3];
-      expect(tabMessage.severity).toBe('error');
-      expect(tabMessage.description).not.toBeDefined();
-      expect(tabMessage.excerpt).toBe('' +
-        '[Generic.PHP.LowerCaseConstant.Found]' +
-        ' TRUE, FALSE and NULL must be lowercase; ' +
-        'expected "true" but found "TRUE"');
-      expect(tabMessage.location.file).toBe(tabsPath);
-      expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
+      checkTabMessage(tabMessage);
     });
 
     it('works with a non-default tab-width', async () => {
@@ -155,18 +163,27 @@ describe('The phpcs provider for Linter', () => {
         expect(messages.length).toBe(3);
         tabMessage = messages[2];
       }
-      expect(tabMessage.severity).toBe('error');
-      expect(tabMessage.description).not.toBeDefined();
-      expect(tabMessage.excerpt).toBe('' +
-        '[Generic.PHP.LowerCaseConstant.Found]' +
-        ' TRUE, FALSE and NULL must be lowercase; ' +
-        'expected "true" but found "TRUE"');
-      expect(tabMessage.location.file).toBe(tabsPath);
-      expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
+      checkTabMessage(tabMessage);
     });
 
     describe('handles forced standards properly', () => {
-      async function checkForcedStandard() {
+      it('works with the default tab width', async () => {
+        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
+        const messages = await lint(editor);
+        let tabMessage;
+        if (satisfies(phpcsVer, '<2')) {
+          expect(messages.length).toBe(3);
+          tabMessage = messages[2];
+        } else {
+          expect(messages.length).toBe(2);
+          tabMessage = messages[1];
+        }
+        checkTabMessage(tabMessage);
+      });
+
+      it('works with a forced tab width', async () => {
+        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
+        atom.config.set('linter-phpcs.tabWidth', 12);
         const messages = await lint(editor);
         let tabMessage;
         if (satisfies(phpcsVer, '<2')) {
@@ -176,28 +193,7 @@ describe('The phpcs provider for Linter', () => {
           expect(messages.length).toBe(2);
           tabMessage = messages[1];
         }
-        expect(tabMessage.severity).toBe('error');
-        expect(tabMessage.description).not.toBeDefined();
-        expect(tabMessage.excerpt).toBe('' +
-        '[Generic.PHP.LowerCaseConstant.Found]' +
-        ' TRUE, FALSE and NULL must be lowercase; ' +
-        'expected "true" but found "TRUE"');
-        expect(tabMessage.location.file).toBe(tabsPath);
-        // Note that for broken versions (v2.0.0 through v3.0.0) the tab width
-        // setting is ignored. We can't test the raw value returned here, but we
-        // can check that it is being handled correctly.
-        expect(tabMessage.location.position).toEqual([[2, 6], [2, 10]]);
-      }
-
-      it('works with the default tab width', async () => {
-        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
-        await checkForcedStandard();
-      });
-
-      it('works with a forced tab width', async () => {
-        atom.config.set('linter-phpcs.codeStandardOrConfigFile', 'PSR2');
-        atom.config.set('linter-phpcs.tabWidth', 12);
-        await checkForcedStandard();
+        checkTabMessage(tabMessage);
       });
     });
   });


### PR DESCRIPTION
If the `tabWidth` setting was left at the default value, a standard that forces the tab width value was in use, and a version of PHPCS was in use that _doesn't_ ignore that setting then the code previously would assume that it didn't need to correct the value coming from PHPCS when it actually did.

This bug was introduced in #260 due to a disconnect between the default value of `1` and the function assuming a default of `0`.