### PR TITLE
Set minimum value for tabWidth setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "tabWidth": {
       "type": "integer",
       "default": 1,
+      "minimum": 1,
       "description": "Set the number of spaces that tab characters represent to PHPCS.",
       "order": 9
     },


### PR DESCRIPTION
As it makes no sense for the tabWidth setting to ever be less than `1`, just set that as a minimum to prevent accidental bad configs.