### PR TITLE
Fix Travis CI beta builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,10 @@ dist: "trusty"
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
+    - g++-6
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
Atom v1.19.0 requires an updated `GLIBCXX` to run currently, fix the Travis CI configuration to accomodate this.