### PR TITLE
Resolve symlinks for PHPCS output

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -99,7 +99,7 @@ const scopeAvailable = (scope, available) => {
   }
 };
 
-const getFileRealPath = async (filePath) =>
+const getFileRealPath = async filePath =>
   new Promise((resolve, reject) => {
     fs.realpath(filePath, (err, resolvedPath) => {
       if (err) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,6 +7,7 @@ let semver;
 let minimatch;
 let helpers;
 let path;
+let fs;
 
 function loadDeps() {
   if (!semver) {
@@ -20,6 +21,9 @@ function loadDeps() {
   }
   if (!path) {
     path = require('path');
+  }
+  if (!fs) {
+    fs = require('fs');
   }
 }
 
@@ -94,6 +98,16 @@ const scopeAvailable = (scope, available) => {
     grammarScopes.push(scope);
   }
 };
+
+const getFileRealPath = async (filePath) =>
+  new Promise((resolve, reject) => {
+    fs.realpath(filePath, (err, resolvedPath) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(resolvedPath);
+    });
+  });
 
 export default {
   activate() {
@@ -313,7 +327,7 @@ export default {
 
         let messages;
         if (semver.gte(version, '2.0.0')) {
-          let fileRealPath = fs.realpathSync(filePath);
+          const fileRealPath = await getFileRealPath(filePath);
           if (!data.files[fileRealPath]) {
             return [];
           }


### PR DESCRIPTION
Problem solved:
- `textEditor.getPath()` returns path with symbolic link;
- PHPCS returns its messages indexed by file real path;
This commit creates a `fileRealPath` variable and search for it into data.files.

Fixes #293.