### PR TITLE
Support . in front of config files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -238,7 +238,10 @@ export default {
         }
 
         // Check if a config file exists and handle it
-        const confFileNames = ['phpcs.xml', 'phpcs.xml.dist', 'phpcs.ruleset.xml', 'ruleset.xml'];
+        const confFileNames = [
+          '.phpcs.xml', '.phpcs.xml.dist', 'phpcs.xml', 'phpcs.xml.dist',
+          'phpcs.ruleset.xml', 'ruleset.xml',
+        ];
         const confFile = await helpers.findAsync(fileDir, confFileNames);
         if (this.disableWhenNoConfigFile && !confFile) {
           return [];


### PR DESCRIPTION
As of v3.1.0 PHP_CodeSniffer supports having a `.` in front of the configuration file name. Replicate this change here.

Fixes #292.