### PR TITLE
Bail early if no `filePath` exists to use

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -186,6 +186,11 @@ export default {
       lintsOnChange: true,
       lint: async (textEditor) => {
         const filePath = textEditor.getPath();
+        if (!filePath) {
+          // TextEditor has no path associated with it (yet), bail early
+          return null;
+        }
+
         const fileText = textEditor.getText();
 
         if (fileText === '') {


### PR DESCRIPTION
Checks to make sure we got a `filePath` from the `textEditor` and if not return null (no update).

Fix #296 