### PR TITLE
Add branch to the CircleCI cache hierarchy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,6 @@ defaults: &defaults
         name: APM version
         command: ${APM_SCRIPT_PATH} --version
     - run:
-        name: Cleaning package
-        command: ${APM_SCRIPT_PATH} clean
-    - run:
         name: Package APM package dependencies
         command: |
           if [ -n "${APM_TEST_PACKAGES}" ]; then
@@ -84,6 +81,9 @@ defaults: &defaults
     - run:
         name: Package dependencies
         command: ${APM_SCRIPT_PATH} install
+    - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
     - run:
         name: Package specs
         command: ${ATOM_SCRIPT_PATH} --test spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,12 @@ defaults: &defaults
     - restore_cache:
         keys:
         # Get latest cache for the current specs
-        - v1-composer-{{ arch }}-{{ checksum ".circleci/config.yml" }}
-        # Fallback to the last available cache
-        - v1-composer-{{ arch }}
+        - v2-composer-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
+        # Fall back to the last cache from this branch
+        - v2-composer-{{ arch }}-{{ .Branch }}-
+        # Fallback to the last available cache from the master branch
+        - v2-composer-{{ arch }}-master-
+        # Don't fall back any further
     - run:
         name: Install PHP
         # PHP requires tzdata, which requires configuring and pauses for input
@@ -88,12 +91,12 @@ defaults: &defaults
     - save_cache:
         paths:
           - node_modules
-        key: v1-dependencies-{{ checksum "package.json" }}
+        key: v2-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
     # Cache Composer
     - save_cache:
         paths:
           - "~/.composer"
-        key: v1-composer-{{ arch }}-{{ checksum ".circleci/config.yml" }}
+        key: v2-composer-{{ arch }}-{{ .Branch }}-{{ checksum ".circleci/config.yml" }}
 
 jobs:
   checkout_code:
@@ -105,10 +108,15 @@ jobs:
       # Restore node_modules from the last build
       - restore_cache:
           keys:
-          # Get latest cache for this package.json
-          - v1-dependencies-{{ checksum "package.json" }}
-          # Fallback to the last available cache
-          - v1-dependencies
+          # Get latest cache for this package.json and package-lock.json
+          - v2-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          # Fallback to the current package.json
+          - v2-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-
+          # Fallback to the last build for this branch
+          - v2-dependencies-{{ .Branch }}-
+          # Fallback to the last available master branch cache
+          - v2-dependencies-master-
+          # Don't go further down to prevent dependency issues from other branches
       # Save project state for next steps
       - persist_to_workspace:
           root: /tmp


### PR DESCRIPTION
Add the current branch to the cache hierarchy, and specify the last cache from the master branch as the last fall back.

This prevents a PR branch that introduces something new or breaking to the cache from poisoning other branches.