### PR TITLE
Remove outdated token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ defaults: &defaults
   docker:
     - image: arcanemagus/atom-docker-ci:stable
   environment:
-    COMPOSER_TOKEN: "cc4a091c096e7d3cfe053c3f669fb840be60ab98"
     COMPOSER_DISABLE_XDEBUG_WARN: 1
     PHPCS_VER: "*"
   steps:
@@ -51,7 +50,7 @@ defaults: &defaults
           echo 'export PATH="/home/atom/.composer/vendor/bin:$PATH"' >> $BASH_ENV
     - run:
         name: Configure Composer token
-        command: composer config -g github-oauth.github.com "${COMPOSER_TOKEN}"
+        command: composer config -g github-oauth.github.com "${COMPOSER_OAUTH_TOKEN}"
     - run:
         name: Composer version
         command: composer --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 env:
   global:
     - COMPOSER_DISABLE_XDEBUG_WARN="1"
-    - COMPOSER_OAUTH_TOKEN="cc4a091c096e7d3cfe053c3f669fb840be60ab98"
     - ATOM_CHANNEL=stable
     - PHPCS_VER="*"
 php: 7.3


### PR DESCRIPTION
The old plaintext token has been invalidated, an encrypted one has been defined in the web interface for Travis CI and Circle CI.