### PR TITLE
feat: adding ./bin/ to the list of autoloaded phpcs paths

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -203,7 +203,10 @@ export default {
 
         // Check if a local PHPCS executable is available
         if (this.autoExecutableSearch) {
-          const phpcsNames = ['vendor/bin/phpcs.bat', 'vendor/bin/phpcs'];
+          const phpcsNames = [
+            'vendor/bin/phpcs.bat', 'vendor/bin/phpcs',
+            'bin/phpcs', 'bin/phpcs.bat',
+          ];
           const projExecutable = await helpers.findCachedAsync(fileDir, phpcsNames);
 
           if (projExecutable !== null) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "title": "Search for executables",
       "type": "boolean",
       "default": true,
-      "description": "Automatically search for any `vendor/bin/phpcs.bat` or `vendor/bin/phpcs` executable. Overrides the exectuable defined above.",
+      "description": "Automatically search for any `vendor/bin/` or `bin/` for the `phpcs` executable. Overrides the exectuable defined above.",
       "order": 2
     },
     "codeStandardOrConfigFile": {


### PR DESCRIPTION
Some the most important projects that we work with at Automattic has executables such as `phpcs` inside of the `./bin` directory as opposed to inside `./vendor/bin/`, making `linter-phpcs` fall back on a global `phpcs` executable.

I'm certain having tools in the `./bin/` directory but not `./vendor/bin/` is common in other legacy codebases as well.

This PR adds `./bin` to the array of directories read by `autoExecutableSearch` and fixes that issue.