### PR TITLE
Fix Composer token for external PRs in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ defaults: &defaults
           echo 'export PATH="/home/atom/.composer/vendor/bin:$PATH"' >> $BASH_ENV
     - run:
         name: Configure Composer token
-        command: composer config -g github-oauth.github.com "${COMPOSER_OAUTH_TOKEN}"
+        command: |
+          [[ -n "${COMPOSER_OAUTH_TOKEN}" ]] && \
+          composer config -g github-oauth.github.com "${COMPOSER_OAUTH_TOKEN}"
     - run:
         name: Composer version
         command: composer --version


### PR DESCRIPTION
The secure `COMPOSER_OAUTH_TOKEN` variable isn't defined for external PR builds, change the build script so if it isn't defined it doesn't attempt to set it, allowing those builds to fallback to the public access. Note that Travis-CI and AppVeyor already work like this.